### PR TITLE
New "rt_enabled" default argument for Threads & new update thread core default argument for ComponentBase

### DIFF
--- a/include/daoComponentBase.hpp
+++ b/include/daoComponentBase.hpp
@@ -32,7 +32,7 @@ namespace Dao
     class ComponentBase : public StateMachine
     {
         public:
-            ComponentBase(std::string name, Dao::Log::Logger& logger, std::string ip, int port, int core=-1)
+            ComponentBase(std::string name, Dao::Log::Logger& logger, std::string ip, int port, int zmq_core=-1, int update_core=-1)
             : StateMachine(logger)
             , m_name(name)
             , m_ip(ip)
@@ -40,8 +40,8 @@ namespace Dao
             , m_log(logger)
             {
                 // create templete message
-                m_zmq_thread = std::make_unique<ComponentZmqThread>(m_name, logger, core, 0);
-                m_update_thread = std::make_unique<ComponentUpdateThread>(m_name, logger);
+                m_zmq_thread = std::make_unique<ComponentZmqThread>(m_name, logger, zmq_core, 0, false);
+                m_update_thread = std::make_unique<ComponentUpdateThread>(m_name, logger, update_core, 0, false);
             }
 
             virtual ~ComponentBase()

--- a/include/daoComponentUpdateThread.hpp
+++ b/include/daoComponentUpdateThread.hpp
@@ -91,8 +91,8 @@ namespace Dao
     class ComponentUpdateThread : public Thread
     {
         public:
-            ComponentUpdateThread(std::string name, Log::Logger& logger, int core=-1, int handle=-1)
-            : Thread("Up_"+ name, logger, core, handle)
+            ComponentUpdateThread(std::string name, Log::Logger& logger, int core=-1, int handle=-1, bool rt_enabled=true)
+            : Thread("Up_"+ name, logger, core, handle, rt_enabled)
             {
 
             }

--- a/include/daoComponentZmqThread.hpp
+++ b/include/daoComponentZmqThread.hpp
@@ -32,8 +32,8 @@ namespace Dao
     class ComponentZmqThread : public Thread
     {
         public:
-            ComponentZmqThread(std::string name, Log::Logger& logger, int core=-1, int handle=-1)
-            : Thread("ZMQ_"+ name, logger, core, handle)
+            ComponentZmqThread(std::string name, Log::Logger& logger, int core=-1, int handle=-1, bool rt_enabled=true)
+            : Thread("ZMQ_"+ name, logger, core, handle, rt_enabled)
             , m_configured(false)
             , m_ip("")
             , m_port(0)

--- a/include/daoThread.hpp
+++ b/include/daoThread.hpp
@@ -24,8 +24,8 @@ namespace Dao
     class Thread: public ThreadBase, public ThreadIfce
     {
         public:
-            Thread(std::string name, Log::Logger& logger, int core=-1, int thread_number=-1)
-            : ThreadBase(name, logger, core, thread_number)
+            Thread(std::string name, Log::Logger& logger, int core=-1, int thread_number=-1, bool rt_enabled=true)
+            : ThreadBase(name, logger, core, thread_number, rt_enabled)
             {
 
             }

--- a/include/daoThreadBase.hpp
+++ b/include/daoThreadBase.hpp
@@ -33,12 +33,13 @@ namespace Dao
              * @brief Default constructor.
              * @param
              */
-            ThreadBase(std::string thread_name, Log::Logger& logger, int core=-1, int thread_number=-1)
+            ThreadBase(std::string thread_name, Log::Logger& logger, int core=-1, int thread_number=-1, bool rt_enabled=true)
             : m_thread_name(thread_name)
             , m_log(logger)
             , m_core(core)
             , m_node(-1)
             , m_thread_number(thread_number)
+            , m_rt_enabled(rt_enabled)
             , m_start(false)
             , m_running(false)
             , m_spawned(false)
@@ -188,8 +189,8 @@ namespace Dao
                     if(rc != 0)
                         std::cout << "Return : " << rc << std::endl;
                 }
-                // setting 
-                if(getuid() == 0)
+                // realtime threads - set RT priority and FIFO scheduling
+                if(getuid() == 0 && m_rt_enabled)
                 {
                     struct sched_param param;
                     param.sched_priority = 95;
@@ -292,6 +293,8 @@ namespace Dao
             volatile bool m_spawned;
             volatile bool m_stop;
             volatile bool m_start_waiting;
+
+            bool m_rt_enabled;
 
             std::thread m_thread;
 


### PR DESCRIPTION
When "rt_enabled" is true (by default), and the application is running with root privileges, the thread will be created with real-time priority and with FIFO scheduling.