### PR TITLE
## Add FIFO (ring buffer) support to DAO shared memory

### DIFF
--- a/docs/source/fifo.rst
+++ b/docs/source/fifo.rst
@@ -53,8 +53,9 @@ A FIFO SHM object allocates contiguous memory for all *N* segments in one go:
 * Each ``IMAGE_METADATA[i]`` holds the counters and flags for segment *i*.
 
 For a depth-1 FIFO the layout is identical to the legacy format, so existing code that was compiled
-against the new headers will continue to work as before — **as long as it uses the FIFO-aware API
-functions**.
+against the new headers will continue to work as before, **as long as it only interacts with
+depth-1 SHMs**. To use SHMs with FIFOs deeper than 1 segment, the code must be updated to use the
+new FIFO-aware functions.
 
 Return Codes
 ------------

--- a/docs/source/fifo.rst
+++ b/docs/source/fifo.rst
@@ -11,9 +11,9 @@ FIFO Shared Memory
    ``get_data()`` / ``get_frame()`` without understanding FIFO semantics) will produce **unexpected
    behaviour** because the underlying memory layout has changed.
 
-   **Windows is not currently supported.** The FIFO extension has only been tested on Linux and
-   macOS.  The Windows code paths (file-mapping objects, Windows semaphores) have not been
-   exercised with FIFO depth > 1 and may fail or produce incorrect results.
+   **Windows is not yet fully tested.** The FIFO extension has only been fully tested on Linux and
+   macOS.  Windows code which relies on FIFO shared memory should work, but you should be aware that
+   unexpected behaviour is possible.
 
 Overview
 --------

--- a/docs/source/fifo.rst
+++ b/docs/source/fifo.rst
@@ -1,0 +1,369 @@
+FIFO Shared Memory
+==================
+
+.. warning::
+
+   **Experimental Feature** — The FIFO shared memory mode is experimental and is **not enabled by default**.
+   All shared memory segments default to a FIFO depth of 1 (standard single-frame behaviour).
+
+   When FIFO mode is enabled, the **new C, C++, and Python FIFO APIs must be used** to read and write
+   data.  Using legacy API calls (e.g., accessing ``image->array.V`` directly, or calling the old
+   ``get_data()`` / ``get_frame()`` without understanding FIFO semantics) will produce **unexpected
+   behaviour** because the underlying memory layout has changed.
+
+   **Windows is not currently supported.** The FIFO extension has only been tested on Linux and
+   macOS.  The Windows code paths (file-mapping objects, Windows semaphores) have not been
+   exercised with FIFO depth > 1 and may fail or produce incorrect results.
+
+Overview
+--------
+
+The standard DAO shared memory model stores exactly one frame per shared memory segment.  The FIFO
+extension adds a circular buffer of *N* independent frames (segments) inside a single shared memory
+object.  Each segment has its own copy of ``IMAGE_METADATA``, so timestamps, counters, and the
+``write`` flag are tracked independently.
+
+A **writer** advances a shared ``fifo_last_written`` index every time a new frame is committed.
+Each **reader** keeps its own private read-tail (``fifo_last_read`` / ``fifo_last_read_cnt0``) that
+lives in the local ``IMAGE`` struct and is therefore never visible to other processes.  Readers can:
+
+* consume frames one-by-one in order (FIFO / sequential mode),
+* always jump to the newest available frame (latest-only / "newest" mode),
+* read arbitrary historical segments by index.
+
+.. note::
+
+   Because the read-tail is local to each ``IMAGE`` struct, multiple independent readers can each
+   maintain their own position without interfering with each other or with the writer.
+
+Memory Layout
+-------------
+
+A FIFO SHM object allocates contiguous memory for all *N* segments in one go:
+
+.. code-block:: text
+
+   [ IMAGE_METADATA[0] | IMAGE_METADATA[1] | ... | IMAGE_METADATA[N-1] ]
+   [ data segment [0]  | data segment [1]  | ... | data segment [N-1]  ]
+
+* ``IMAGE_METADATA[0].fifo_size`` stores the depth *N* and is the authoritative value for all
+  processes.
+* ``IMAGE_METADATA[0].fifo_last_written`` is the index of the segment most recently committed by
+  the writer.
+* Each ``IMAGE_METADATA[i]`` holds the counters and flags for segment *i*.
+
+For a depth-1 FIFO the layout is identical to the legacy format, so existing code that was compiled
+against the new headers will continue to work as before — **as long as it uses the FIFO-aware API
+functions**.
+
+Return Codes
+------------
+
+The FIFO API introduces two new return codes in addition to the existing ``DAO_SUCCESS``,
+``DAO_ERROR``, and ``DAO_TIMEOUT``:
+
+.. list-table::
+   :widths: 20 10 70
+   :header-rows: 1
+
+   * - Constant
+     - Value
+     - Meaning
+   * - ``DAO_OVERWRITE``
+     - ``-2``
+     - The reader's tail was lapped by the writer.  The tail has been reset to the newest segment.
+       The data pointer returned is still valid but some frames were skipped.
+   * - ``DAO_NOTREADY``
+     - ``-3``
+     - No new segment is available yet (the reader is already at the head of the FIFO).
+
+Creating a FIFO Shared Memory Segment
+--------------------------------------
+
+C API
+~~~~~
+
+Use ``daoShmImageCreate_FIFO`` instead of ``daoShmImageCreate``:
+
+.. code-block:: c
+
+   #include "dao.h"
+
+   IMAGE image;
+   uint32_t size[2] = {256, 256};
+   uint32_t fifo_depth = 8;   // keep the last 8 frames
+
+   // Create a FIFO shared memory segment with depth 8
+   daoShmImageCreate_FIFO(&image, "/tmp/mydata.im.shm",
+                          2,          // naxis
+                          size,
+                          _DATATYPE_FLOAT,
+                          1,          // shared = 1 (POSIX shared memory)
+                          0,          // no keywords
+                          fifo_depth);
+
+.. note::
+
+   ``daoShmImageCreate`` is a thin wrapper around ``daoShmImageCreate_FIFO`` with ``fifo_size = 1``
+   and continues to work as before.
+
+C++ API
+~~~~~~~
+
+Pass the optional ``depth`` argument to the ``Dao::Shm`` constructor:
+
+.. code-block:: cpp
+
+   #include "daoShm.hpp"
+
+   // 256×256 float32 SHM with 8-frame FIFO depth
+   Dao::Shm<float> shm("/tmp/mydata.im.shm", {256, 256}, nullptr, /*depth=*/8);
+
+Python API
+~~~~~~~~~~
+
+Pass the ``depth`` keyword argument when creating a ``shm`` object:
+
+.. code-block:: python
+
+   import numpy as np
+   from daoShm import shm
+
+   data = np.zeros((256, 256), dtype=np.float32)
+
+   # Create SHM with FIFO depth of 8 frames
+   shm_obj = shm("/tmp/mydata.im.shm", data=data, depth=8)
+
+Writing Data
+------------
+
+All existing write functions (``daoShmImage2Shm``, ``set_frame()``, ``set_data()`` etc.) have been
+updated to advance the FIFO automatically — no API change is required on the writer side.  Each
+call internally increments ``fifo_last_written`` and writes into the next circular slot.
+
+Reading Data
+------------
+
+C API
+~~~~~
+
+.. list-table::
+   :widths: 35 65
+   :header-rows: 1
+
+   * - Function
+     - Description
+   * - ``daoShmGetNewestSegment``
+     - Returns the most recently written segment.  Equivalent to the old ``image->array.V`` access pattern.
+   * - ``daoShmGetNextSegment``
+     - Advances the reader's tail by one and returns the next unread segment.  Returns ``DAO_OVERWRITE`` if frames were skipped, ``DAO_NOTREADY`` if no new frame is available.
+   * - ``daoShmWaitForNextSegment``
+     - Blocks (using the counter semaphore) until a new segment is written, then returns.  Call ``daoShmGetNextSegment`` immediately after.
+   * - ``daoShmGetArbitrarySegment``
+     - Returns a pointer to a specific FIFO slot by index (wraps modulo ``fifo_size``).
+   * - ``daoShmCheckSegmentOverwrite``
+     - Checks whether the segment last read by this tail has since been overwritten.  Returns ``DAO_OVERWRITE`` if so.
+   * - ``daoShmResetTail``
+     - Resets the reader's tail to the newest segment.  Useful after an overwrite or on initialisation.
+
+**Sequential reading example (C):**
+
+.. code-block:: c
+
+   #include "dao.h"
+
+   IMAGE image;
+   daoShmShm2Img("/tmp/mydata.im.shm", &image);  // open existing SHM
+
+   void   *segment_ptr  = NULL;
+   uint32_t segment_idx = 0;
+   uint64_t segment_cnt0 = 0;
+
+   while (1) {
+       // Block until the next frame arrives
+       daoShmWaitForNextSegment(&image);
+
+       int_fast8_t status = daoShmGetNextSegment(&image, &segment_ptr,
+                                                 &segment_idx, &segment_cnt0);
+
+       if (status == DAO_OVERWRITE) {
+           fprintf(stderr, "Warning: frame(s) were overwritten – reader is too slow\n");
+       }
+
+       float *data = (float *)segment_ptr;
+       // process data …
+   }
+
+**Latest-only reading example (C):**
+
+.. code-block:: c
+
+   daoShmGetNewestSegment(&image, &segment_ptr, &segment_idx, &segment_cnt0);
+   float *data = (float *)segment_ptr;
+
+C++ API
+~~~~~~~
+
+.. list-table::
+   :widths: 35 65
+   :header-rows: 1
+
+   * - Method
+     - Description
+   * - ``get_frame()``
+     - Returns the **newest** segment.  Existing synchronisation options (semaphore, counter spin) still work.
+   * - ``get_next_frame(wait, status)``
+     - Advances the tail and returns the next unread segment.  ``status`` is set to ``DAO_OVERWRITE`` if frames were skipped.
+   * - ``get_next_frame(wait, status, cnt0)``
+     - As above but also fills ``cnt0`` with the segment counter value.
+   * - ``get_arbitrary_frame(segment_idx)``
+     - Returns a pointer to an arbitrary FIFO slot.
+   * - ``check_segment_overwrite()``
+     - Returns ``DAO_OVERWRITE`` if the last-read segment has been overwritten.
+   * - ``get_counter(fifo_idx)``
+     - Returns ``cnt0`` for a specific FIFO slot.
+   * - ``get_meta_data(fifo_idx)``
+     - Returns a pointer to ``IMAGE_METADATA`` for a specific FIFO slot.
+
+**Sequential reading example (C++):**
+
+.. code-block:: cpp
+
+   #include "daoShm.hpp"
+
+   Dao::Shm<float> shm("/tmp/mydata.im.shm");  // open existing SHM
+
+   while (true) {
+       int_fast8_t status;
+       float *data = shm.get_next_frame(/*wait=*/true, status);
+
+       if (status == DAO_OVERWRITE) {
+           std::cerr << "Warning: frame(s) overwritten – reader is too slow\n";
+       }
+       // process data …
+   }
+
+Python API
+~~~~~~~~~~
+
+.. list-table::
+   :widths: 35 65
+   :header-rows: 1
+
+   * - Method
+     - Description
+   * - ``get_data()``
+     - Returns the **newest** segment as a NumPy array.
+   * - ``get_data_next(wait, reform)``
+     - Advances the tail and returns the next unread segment.  Returns ``(status, array)`` where *status* is one of the class constants (``DAO_SUCCESS``, ``DAO_OVERWRITE``, ``DAO_NOTREADY``).
+   * - ``get_data_arbitrary(index)``
+     - Returns the segment at the given FIFO index as a NumPy array.
+   * - ``get_history(num_items)``
+     - Returns the last *num_items* segments stacked along axis 0 as a single NumPy array.
+   * - ``get_meta_data(index)``
+     - Returns metadata for the newest segment (``index=None``) or for a specific FIFO slot.
+
+**Sequential reading example (Python):**
+
+.. code-block:: python
+
+   from daoShm import shm
+
+   shm_obj = shm("/tmp/mydata.im.shm")  # open existing SHM
+
+   while True:
+       status, data = shm_obj.get_data_next(wait=True)
+
+       if status == shm.DAO_OVERWRITE:
+           print("Warning: frame(s) overwritten – reader is too slow")
+       elif status == shm.DAO_NOTREADY:
+           continue  # no new frame yet
+
+       # process data (NumPy array) …
+
+**Reading recent history (Python):**
+
+.. code-block:: python
+
+   # Retrieve the last 4 frames as a (4, 256, 256) NumPy array
+   history = shm_obj.get_history(num_items=4)
+
+Overwrite Detection
+-------------------
+
+Because the FIFO is a circular buffer, a slow reader can be lapped by a fast writer.  There are two
+mechanisms to detect this:
+
+1. **Inline with** ``get_data_next`` / ``get_next_frame`` / ``daoShmGetNextSegment``:
+   The return value is ``DAO_OVERWRITE`` whenever the tail was behind the writer by more than one
+   full FIFO cycle.  The tail is automatically reset to the newest segment.
+
+2. **Explicit check** via ``check_segment_overwrite`` / ``daoShmCheckSegmentOverwrite``:
+   Checks whether the ``write`` flag or ``cnt0`` of the last-read slot has changed since the read.
+   Useful if you copy data out of shared memory and then want to validate the copy.
+
+To avoid overwrite events, increase the FIFO depth or reduce the time between reader calls.
+
+FIFO Depth Considerations
+--------------------------
+
+The primary motivation for using a FIFO depth greater than 1 is **retaining a history of frames**
+in shared memory.  Two typical use-cases drive the choice of depth:
+
+**Telemetry and diagnostics**
+   A telemetry or logging process can read back the last *N* frames at any time using
+   ``get_history()`` / ``daoShmGetArbitrarySegment``.  This gives a rolling window of recent
+   data without requiring a separate ring-buffer or file-write on every cycle.  The depth should
+   cover at least the longest expected gap between telemetry reads.
+
+**Algorithms that depend on previous results**
+   Many adaptive optics algorithms (predictive controllers, integrators, temporal filters) need
+   access to one or more past frames at each iteration.  Rather than maintaining separate history
+   buffers inside the component, the FIFO provides this history directly in shared memory,
+   accessible to any process that holds an ``IMAGE`` handle.  Choose a depth equal to the number
+   of past frames the algorithm requires, plus a margin for scheduling jitter.
+
+The FIFO depth multiplies the shared memory allocation:
+
+.. code-block:: text
+
+   Total size ≈ N × (sizeof(IMAGE_METADATA) + nelement × sizeof(element_type))
+               + semaphores + keywords
+
+Typical guidance:
+
+* Depth **1** — identical to standard (non-FIFO) behaviour.  No overhead.
+* Depth **2–8** — sufficient for algorithms requiring a small number of past frames (e.g.,
+  a first- or second-order temporal filter).
+* Depth **10–100** — suitable for telemetry windows, longer predictive filters, or components
+  that process data in bursts rather than frame-by-frame.
+* Depth **> 100** — feasible for large telemetry histories; bear in mind that the entire buffer
+  lives in RAM.  For very long histories consider whether a dedicated file-based ring buffer is
+  more appropriate.
+
+Thread Safety
+-------------
+
+* The **writer** side (``daoShmImage2Shm`` and equivalents) is safe to call from a single writer
+  thread.  Concurrent writers are not supported.
+* Multiple **readers** are safe because each reader's tail is stored in its own local ``IMAGE``
+  struct.  Readers never modify shared memory.
+* The ``write`` flag in each segment's ``IMAGE_METADATA`` provides a lightweight consistency
+  indicator but is **not** a full memory barrier.  Use ``daoShmCheckSegmentOverwrite`` if strict
+  data integrity is required.
+
+Backwards Compatibility
+------------------------
+
+All existing code that creates SHM with ``daoShmImageCreate`` (depth 1) will continue to compile
+and run correctly — the function now delegates to ``daoShmImageCreate_FIFO`` with ``fifo_size = 1``.
+
+Code that **loads** an existing SHM (``daoShmShm2Img``) reads ``fifo_size`` from the metadata and
+adjusts all internal offsets automatically, so readers compiled with the new headers can open both
+depth-1 and depth-N segments transparently.
+
+.. warning::
+
+   SHM segments created with the **old** library (before the FIFO branch was merged) have
+   ``fifo_size = 0`` in memory, which the new loader interprets incorrectly.  Delete and recreate
+   any existing shared memory files after upgrading to the FIFO-enabled build.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,27 @@ Durham Adaptive Optics (DAO)
       </div>
    </div>
 
+.. warning::
+
+   **Experimental Feature: FIFO Shared Memory**
+
+   A FIFO (circular buffer) extension to the shared memory system is available on the
+   ``feature/fifo`` branch.  It is **experimental**, **not enabled by default**, and is **not yet
+   merged into the main release**.
+
+   * All shared memory segments default to a FIFO depth of **1** (standard single-frame
+     behaviour).  Existing code is unaffected unless you explicitly pass ``depth > 1``.
+   * When FIFO mode is used (``depth > 1``), you **must** use the new FIFO-aware C, C++, or Python
+     API calls (``daoShmImageCreate_FIFO``, ``get_next_frame``, ``get_data_next``, etc.).
+     Accessing the underlying array pointer directly or using legacy read paths against a FIFO
+     segment **will produce incorrect or undefined behaviour**.
+   * The API and memory layout may change before the feature is finalised.
+   * **Windows is not currently supported.** The FIFO code path has only been tested on Linux
+     and macOS.  Building or running FIFO-enabled code on Windows may fail or produce incorrect
+     results.
+
+   See :doc:`fifo` for full documentation.
+
 Why Choose DAO?
 ===============
 
@@ -127,6 +148,10 @@ Documentation Guide
             <h4>Shared Memory System</h4>
             <p>Low-latency inter-process communication foundation</p>
          </a>
+         <a href="fifo.html" class="doc-link">
+            <h4>FIFO Shared Memory <span style="font-size:0.75em;color:#e67e22;">(Experimental)</span></h4>
+            <p>Circular-buffer extension for multi-frame shared memory</p>
+         </a>
          <a href="threads.html" class="doc-link">
             <h4>Thread Management</h4>
             <p>Real-time thread system and lifecycle management</p>
@@ -223,6 +248,7 @@ Need help optimising your adaptive optics real-time control system? We've recent
    :caption: Core Concepts
 
    shared_memory
+   fifo
    daoComponent
    threads
    state_machine

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,9 +23,8 @@ Durham Adaptive Optics (DAO)
 
    **Experimental Feature: FIFO Shared Memory**
 
-   A FIFO (circular buffer) extension to the shared memory system is available on the
-   ``feature/fifo`` branch.  It is **experimental**, **not enabled by default**, and is **not yet
-   merged into the main release**.
+   A FIFO (circular buffer) extension to the shared memory system is now available.
+   It is **experimental**, and **not yet enabled by default**.
 
    * All shared memory segments default to a FIFO depth of **1** (standard single-frame
      behaviour).  Existing code is unaffected unless you explicitly pass ``depth > 1``.
@@ -34,7 +33,7 @@ Durham Adaptive Optics (DAO)
      Accessing the underlying array pointer directly or using legacy read paths against a FIFO
      segment **will produce incorrect or undefined behaviour**.
    * The API and memory layout may change before the feature is finalised.
-   * **Windows is not currently supported.** The FIFO code path has only been tested on Linux
+   * **Windows support is experimental.** The FIFO code path has only been fully tested on Linux
      and macOS.  Building or running FIFO-enabled code on Windows may fail or produce incorrect
      results.
 

--- a/docs/source/shared_memory.rst
+++ b/docs/source/shared_memory.rst
@@ -149,6 +149,22 @@ To properly clean up resources:
 
 Additionally, the `__del__` method ensures resources are freed when the object is garbage collected.
 
+FIFO (Circular Buffer) Mode
+---------------------------
+
+.. warning::
+
+   FIFO mode is **experimental** and is **not enabled by default**.  A standard shared memory
+   segment has a FIFO depth of 1 (single-frame behaviour).  When a depth greater than 1 is
+   requested, the **new FIFO-specific API must be used** — mixing legacy direct array access with a
+   depth-N segment will produce undefined behaviour.
+
+The DAO shared memory system supports an optional FIFO (circular buffer) mode that retains the last
+*N* frames inside a single shared memory object.  This is useful when the reader may occasionally
+stall, or when historical frames need to be inspected.
+
+See :doc:`fifo` for a complete description of the FIFO API, memory layout, and usage examples.
+
 ZeroMQ Integration
 ------------------
 
@@ -169,26 +185,32 @@ The shared memory system can optionally integrate with ZeroMQ for network commun
    remote_shm.subThread.start()
 
 C++ Interface
------------
+-------------
 
 For C++ developers, including the ``daoShm.hpp`` header provides access
 to the following shared memory interface:
 
 .. code-block:: cpp
 
-   // Create a shared memory segment.
-   Dao::Shm(const std::string &name, const Dao::Shape &shape, T *frame); // initialize frame.
-   Dao::Shm(const std::string &name, const Dao::Shape &shape);
+   // Create a shared memory segment (depth=1 by default; use depth>1 for FIFO mode).
+   Dao::Shm(const std::string &name, const Dao::Shape &shape, T *frame = nullptr,
+            uint32_t depth = 1);
 
-   // Open an exisiting shared memory segment.
+   // Open an existing shared memory segment.
    Dao::Shm(const std::string &name);
 
    // Write frame to shared memory.
    Dao::Shm::set_frame(const T *frame);
 
-   // Get shared memory frame.
-   T* Dao::Shm::get_frame(Dao::ShmSync sync); // with synchronization.
-   T* Dao::Shm::get_frame(); // no synchronization.
+   // Get the newest frame (with optional synchronization).
+   T* Dao::Shm::get_frame(Dao::ShmSync sync);
+   T* Dao::Shm::get_frame();
+
+   // FIFO-mode reading (see fifo.rst for full details).
+   T* Dao::Shm::get_next_frame(bool wait, int_fast8_t &status);
+   T* Dao::Shm::get_next_frame(bool wait, int_fast8_t &status, uint64_t &cnt0);
+   T* Dao::Shm::get_arbitrary_frame(uint32_t segment_idx);
+   int_fast8_t Dao::Shm::check_segment_overwrite();
 
 Information on the full C++ interface can be found in the Doxygen documentation.
 
@@ -199,20 +221,32 @@ Both the C++ and Python interfaces are lightweight wrappers around the C library
 
 .. code-block:: c
 
-   // Create a shared memory segment
+   // Create a standard (depth-1) shared memory segment
    int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis, uint32_t *size,
                                 uint8_t atype, int shared, int NBkw);
-   
+
+   // Create a FIFO shared memory segment with depth N (experimental)
+   int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis, uint32_t *size,
+                                      uint8_t atype, int shared, int NBkw, uint32_t fifo_size);
+
    // Access an existing shared memory segment
    int_fast8_t daoShmShm2Img(const char *name, IMAGE *image);
-   
-   // Write data to shared memory
+
+   // Write data to shared memory (advances the FIFO automatically)
    int_fast8_t daoShmImage2Shm(void *im, uint32_t nbVal, IMAGE *image);
-   
+
    // Wait for updates
    int_fast8_t daoShmWaitForSemaphore(IMAGE *image, int32_t semNb);
    int_fast8_t daoShmWaitForCounter(IMAGE *image);
-   
+
+   // FIFO reading (experimental – see fifo.rst for full details)
+   int_fast8_t daoShmGetNewestSegment(IMAGE *image, void **ptr, uint32_t *idx, uint64_t *cnt0);
+   int_fast8_t daoShmGetNextSegment(IMAGE *image, void **ptr, uint32_t *idx, uint64_t *cnt0);
+   int_fast8_t daoShmWaitForNextSegment(IMAGE *image);
+   int_fast8_t daoShmGetArbitrarySegment(IMAGE *image, void **ptr, uint_fast32_t fifo_idx);
+   int_fast8_t daoShmCheckSegmentOverwrite(IMAGE *image);
+   int_fast8_t daoShmResetTail(IMAGE *image, uint32_t *idx, uint64_t *cnt0);
+
    // Clean up
    int_fast8_t daoShmCloseShm(IMAGE *image);
 

--- a/include/dao.h
+++ b/include/dao.h
@@ -121,6 +121,8 @@ extern "C"
 #define IMAGE_NB_SEMAPHORE  10            /**< Number of semaphores per image */
 #define CIRCULAR_BUFFER_SIZE 1000         /**< Number of data in the cuircular buffer */
 
+#define DAO_MAX_COMBINE_CHANNELS 1024     /**< Maximum number of channels that can be combined by daoShmCombineShm2Shm */
+
 // Data types are defined as machine-independent types for portability
 
 #define _DATATYPE_UINT8                                1  /**< uint8_t       = char */

--- a/include/dao.h
+++ b/include/dao.h
@@ -468,6 +468,31 @@ typedef struct          		/**< structure used to store data arrays              
     uint32_t fifo_last_read;
     uint64_t fifo_last_read_cnt0;
 
+    union
+    {
+        uint8_t *UI8;  // char
+        int8_t  *SI8;   
+
+        uint16_t *UI16; // unsigned short
+        int16_t *SI16;  
+
+        uint32_t *UI32;
+        int32_t *SI32;   // int
+
+        uint64_t *UI64;        
+        int64_t *SI64; // long
+
+        float *F;
+        double *D;
+        
+        complex_float *CF;
+        complex_double *CD;
+
+        void * V; // add so the cpp interface and reinterpret cast using templaces to required type.
+    } base_array;                 	/**< pointer to base of FIFO array */
+
+    IMAGE_METADATA *base_md;        /**< pointer to base of metadata array */
+
     // total size is 152 byte = 1216 bit
     // (on Windows,  160 byte = 1280 bit)
 #ifdef DATA_PACKED

--- a/include/dao.h
+++ b/include/dao.h
@@ -69,6 +69,7 @@ void daoLogSetLevel(int log_level);
 #define DAO_SUCCESS     0
 #define DAO_ERROR       1
 #define DAO_TIMEOUT     -1
+#define DAO_OVERWRITE   -2
 
 #define DAO_WARNING 0
 #define DAO_INFO 1
@@ -460,8 +461,9 @@ typedef struct          		/**< structure used to store data arrays              
 	HANDLE shmfm;						/**< shared memory file mapping view handle */
 #endif
 
-    // New FIFO member
+    // New FIFO members
     uint32_t fifo_last_read;
+    uint64_t fifo_last_read_cnt0;
 
     // total size is 152 byte = 1216 bit
     // (on Windows,  160 byte = 1280 bit)
@@ -497,12 +499,21 @@ DLL_EXPORT int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, lo
                            uint8_t atype, int shared, int NBkw, uint32_t fifo_size);
 DLL_EXPORT int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis, uint32_t *size,
                            uint8_t atype, int shared, int NBkw);
+
 DLL_EXPORT int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCude, IMAGE *image, int nbChannel, int nbVal); 
 DLL_EXPORT int_fast8_t daoShmWaitForSemaphore(IMAGE *image, int32_t semNb);
 DLL_EXPORT int_fast8_t daoShmWaitForSemaphoreTimeout(IMAGE *image, int32_t semNb, const struct timespec *timeout);
 DLL_EXPORT int_fast8_t daoShmWaitForCounter(IMAGE *image);
 DLL_EXPORT int_fast8_t daoShmWaitForTargetCounter(IMAGE *image, uint64_t targetCnt0);
 DLL_EXPORT uint64_t    daoShmGetCounter(IMAGE *image);
+
+DLL_EXPORT int_fast8_t daoShmGetNextSegment(IMAGE *image, void** segmentPtr, uint32_t* segmentIdx);
+DLL_EXPORT int_fast8_t daoShmWaitForNextSegment(IMAGE *image);
+DLL_EXPORT int_fast8_t daoShmGetArbitrarySegment(IMAGE *image, void** segmentPtr, uint_fast32_t fifoIdx);
+DLL_EXPORT int_fast8_t daoShmGetNewestSegment(IMAGE *image, void** segmentPtr, uint32_t* segmentIdx);
+DLL_EXPORT int_fast8_t daoShmCheckSegmentOverwrite(IMAGE *image);
+DLL_EXPORT int_fast8_t daoShmResetTail(IMAGE *image, uint32_t* segmentIdx);
+
 DLL_EXPORT int_fast8_t daoShmCloseShm(IMAGE *image);
 DLL_EXPORT int_fast8_t daoShmTimestampShm(IMAGE *image);
 

--- a/include/dao.h
+++ b/include/dao.h
@@ -332,6 +332,11 @@ typedef struct
         atomic_uint semCounter[IMAGE_NB_SEMAPHORE];
         atomic_uint semLogCounter;
 #endif
+
+    // FIFO members
+    uint32_t fifo_size;
+    uint32_t fifo_last_write;
+
 #ifdef DATA_PACKED
 } __attribute__ ((__packed__)) IMAGE_METADATA;
 #else
@@ -455,6 +460,9 @@ typedef struct          		/**< structure used to store data arrays              
 	HANDLE shmfm;						/**< shared memory file mapping view handle */
 #endif
 
+    // New FIFO member
+    uint32_t fifo_last_read;
+
     // total size is 152 byte = 1216 bit
     // (on Windows,  160 byte = 1280 bit)
 #ifdef DATA_PACKED
@@ -485,6 +493,8 @@ DLL_EXPORT int_fast8_t daoShmImagePart2Shm(char *im, uint32_t nbVal, IMAGE *imag
                              uint16_t packetId, uint16_t packetTotal, uint64_t frameNumber); 
 DLL_EXPORT int_fast8_t daoShmImagePart2ShmFinalize(IMAGE *image); 
 DLL_EXPORT int_fast8_t daoShmImageCreateSem(IMAGE *image, long NBsem);
+DLL_EXPORT int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis, uint32_t *size,
+                           uint8_t atype, int shared, int NBkw, uint32_t fifo_size);
 DLL_EXPORT int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis, uint32_t *size,
                            uint8_t atype, int shared, int NBkw);
 DLL_EXPORT int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCude, IMAGE *image, int nbChannel, int nbVal); 

--- a/include/dao.h
+++ b/include/dao.h
@@ -335,7 +335,7 @@ typedef struct
 
     // FIFO members
     uint32_t fifo_size;
-    uint32_t fifo_last_write;
+    uint32_t fifo_last_written;
 
 #ifdef DATA_PACKED
 } __attribute__ ((__packed__)) IMAGE_METADATA;

--- a/include/dao.h
+++ b/include/dao.h
@@ -70,6 +70,7 @@ void daoLogSetLevel(int log_level);
 #define DAO_ERROR       1
 #define DAO_TIMEOUT     -1
 #define DAO_OVERWRITE   -2
+#define DAO_NOTREADY    -3
 
 #define DAO_WARNING 0
 #define DAO_INFO 1
@@ -507,12 +508,12 @@ DLL_EXPORT int_fast8_t daoShmWaitForCounter(IMAGE *image);
 DLL_EXPORT int_fast8_t daoShmWaitForTargetCounter(IMAGE *image, uint64_t targetCnt0);
 DLL_EXPORT uint64_t    daoShmGetCounter(IMAGE *image);
 
-DLL_EXPORT int_fast8_t daoShmGetNextSegment(IMAGE *image, void** segmentPtr, uint32_t* segmentIdx);
+DLL_EXPORT int_fast8_t daoShmGetNextSegment(IMAGE *image, void** segment_ptr, uint32_t* segment_idx, uint64_t *segment_cnt0);
 DLL_EXPORT int_fast8_t daoShmWaitForNextSegment(IMAGE *image);
-DLL_EXPORT int_fast8_t daoShmGetArbitrarySegment(IMAGE *image, void** segmentPtr, uint_fast32_t fifoIdx);
-DLL_EXPORT int_fast8_t daoShmGetNewestSegment(IMAGE *image, void** segmentPtr, uint32_t* segmentIdx);
+DLL_EXPORT int_fast8_t daoShmGetArbitrarySegment(IMAGE *image, void** segment_ptr, uint_fast32_t fifo_idx);
+DLL_EXPORT int_fast8_t daoShmGetNewestSegment(IMAGE *image, void** segment_ptr, uint32_t* segment_idx, uint64_t *segment_cnt0);
 DLL_EXPORT int_fast8_t daoShmCheckSegmentOverwrite(IMAGE *image);
-DLL_EXPORT int_fast8_t daoShmResetTail(IMAGE *image, uint32_t* segmentIdx);
+DLL_EXPORT int_fast8_t daoShmResetTail(IMAGE *image, uint32_t* segment_idx, uint64_t *segment_cnt0);
 
 DLL_EXPORT int_fast8_t daoShmCloseShm(IMAGE *image);
 DLL_EXPORT int_fast8_t daoShmTimestampShm(IMAGE *image);

--- a/include/dao.h
+++ b/include/dao.h
@@ -468,31 +468,6 @@ typedef struct          		/**< structure used to store data arrays              
     uint32_t fifo_last_read;
     uint64_t fifo_last_read_cnt0;
 
-    union
-    {
-        uint8_t *UI8;  // char
-        int8_t  *SI8;   
-
-        uint16_t *UI16; // unsigned short
-        int16_t *SI16;  
-
-        uint32_t *UI32;
-        int32_t *SI32;   // int
-
-        uint64_t *UI64;        
-        int64_t *SI64; // long
-
-        float *F;
-        double *D;
-        
-        complex_float *CF;
-        complex_double *CD;
-
-        void * V; // add so the cpp interface and reinterpret cast using templaces to required type.
-    } base_array;                 	/**< pointer to base of FIFO array */
-
-    IMAGE_METADATA *base_md;        /**< pointer to base of metadata array */
-
     // total size is 152 byte = 1216 bit
     // (on Windows,  160 byte = 1280 bit)
 #ifdef DATA_PACKED

--- a/include/daoShm.hpp
+++ b/include/daoShm.hpp
@@ -39,18 +39,20 @@ namespace Dao
          * @param shape Dao::Shape containing number of elements in each axis.
          * @param frame Initial shared memory data frame.
          */
-        Shm(const std::string &name, const Dao::Shape &shape, T *frame = nullptr) {
+        Shm(const std::string &name, const Dao::Shape &shape, T *frame = nullptr,
+            uint32_t depth = 1) {
             if(shape.size() != 2 && shape.size() != 3)
                 throw std::runtime_error("invalid dao shape");
 
-            const auto status = daoShmImageCreate(
+            const auto status = daoShmImageCreate_FIFO(
                 &image_,
                 name.c_str(),
                 shape.size(),
                 (uint32_t*)shape.data(),
                 inferDaoType(),
                 1, // shared memory
-                0 // no keywords
+                0, // no keywords
+                depth
             );
             md_ = (volatile IMAGE_METADATA *)image_.md;
             
@@ -115,7 +117,7 @@ namespace Dao
         }
 
         /**
-         * @brief Retrieve a pointer to the shared memory frame array.
+         * @brief Retrieve a pointer to the newest segment of the shared memory frame array.
          * Optionally blocks until the next frame is written to shared memory.
          * @param sync Synchronization option (see Dao::ShmSync).
          * @param syncValue Specifies the timeout (seconds) for the semaphore sync options, or the cnt0 value to sync on when using the SPIN sync option.
@@ -141,7 +143,56 @@ namespace Dao
                         return nullptr;
                 } break;
             }
-            return (T*)image_.array.V;
+
+            void *newest_data;
+            uint32_t segment_idx;
+            uint64_t segment_cnt0;
+            daoShmGetNewestSegment(&image_, &newest_data, &segment_idx, &segment_cnt0);
+
+            return (T*)newest_data;
+        }
+
+        /**
+         * @brief Retrieve a pointer to the next segment of the shared memory frame array.
+         * Optionally blocks until the next frame is written to shared memory.
+         * @param bool Flag to enable spinning until new frame is ready
+         * @param overwrite Reference to flag indicating frame overwrite (optional)
+         * @return Pointer to the shared memory frame array, or nullptr if synchronization failed (wait enabled),
+         * or if frame is not yet ready (wait disabled)
+         */
+        T* get_next_frame(bool wait, uint_fast8_t &status) {
+            // Wait for the next frame if requested
+            if (wait) {
+                if (daoShmWaitForNextSegment(&image_) != DAO_SUCCESS)
+                    status = DAO_ERROR;
+                    return nullptr;
+            }
+
+            // Get the next frame
+            void *segment_ptr;
+            uint32_t segment_idx;
+            uint64_t segment_cnt0;
+
+            status = daoShmGetNextSegment(&image_, &segment_ptr, &segment_idx, &segment_cnt0);
+
+            return (T*)segment_ptr;
+        }
+
+        /**
+         * @brief Retrieve a pointer to a given segment of the shared memory frame array.
+         * @param bool Flag to enable spinning until new frame is ready
+         * @param overwrite Reference to flag indicating frame overwrite (optional)
+         * @return Pointer to the shared memory frame array, or nullptr if synchronization failed (wait enabled),
+         * or if frame is not yet ready (wait disabled)
+         */
+        T* get_arbitrary_frame(uint32_t segment_idx) {
+            // Get the next frame
+            void *segment_ptr;
+            uint64_t *segment_cnt0;
+
+            daoShmGetArbitrarySegment(&image_, &segment_ptr, segment_idx);
+
+            return segment_ptr;
         }
 
         /**
@@ -165,7 +216,17 @@ namespace Dao
          * @return cnt0.
          */
         uint64_t get_counter() const {
-            return md_->cnt0;
+            return this->get_counter(md_->fifo_last_written);
+        }
+
+        /**
+         * @brief Get arbitrary metadata cnt0 value.
+         * @return cnt0.
+         */
+        uint64_t get_counter(uint32_t fifo_idx) const {
+            volatile IMAGE_METADATA *segment_md_ = &(md_[fifo_idx % (md_->fifo_size)]);
+
+            return segment_md_->cnt0;
         }
 
         /**
@@ -173,7 +234,17 @@ namespace Dao
          * @return cnt1.
          */
         uint64_t get_cnt1() const {
-            return md_->cnt1;
+            return this->get_cnt1(md_->fifo_last_written);
+        }
+
+        /**
+         * @brief Get arbitrary cnt1 value.
+         * @return cnt1.
+         */
+        uint64_t get_cnt1(uint32_t fifo_idx) const {
+            volatile IMAGE_METADATA *segment_md_ = &(md_[fifo_idx % (md_->fifo_size)]);
+
+            return segment_md_->cnt1;
         }
 
         /**
@@ -181,7 +252,17 @@ namespace Dao
          * @return frame id (cnt2).
          */
         uint64_t get_frame_id() const {
-            return md_->cnt2;
+            return this->get_frame_id(md_->fifo_last_written);
+        }
+
+        /**
+         * @brief Get arbitrary frame id (cnt2).
+         * @return frame id (cnt2).
+         */
+        uint64_t get_frame_id(uint32_t fifo_idx) const {
+            volatile IMAGE_METADATA *segment_md_ = &(md_[fifo_idx % (md_->fifo_size)]);
+
+            return segment_md_->cnt2;
         }
 
         /**
@@ -189,14 +270,34 @@ namespace Dao
          * @return Seconds since Unix epoch.
          */
         int64_t get_timestamp() const {
+            return this->get_timestamp(md_->fifo_last_written);
+        }
+
+        /**
+         * @brief Get arbitrary timestamp value.
+         * @return Seconds since Unix epoch.
+         */
+        int64_t get_timestamp(uint32_t fifo_idx) const {
             return md_->atime.tsfixed.secondlong;
         }
 
         /**
          * @brief Get shared memory metadata.
-         * @return Poiter to shared memory metadata structure.
+         * @return Pointer to shared memory metadata structure.
          */
-        IMAGE_METADATA* get_meta_data() const { return image_.md; }
+        IMAGE_METADATA* get_meta_data() const {
+            return this->get_meta_data(md_->fifo_last_written);
+        }
+
+        /**
+         * @brief Get shared memory metadata.
+         * @return Pointer to shared memory metadata structure.
+         */
+        IMAGE_METADATA* get_meta_data(uint32_t fifo_idx) const {
+            volatile IMAGE_METADATA *segment_md_ = &(md_[fifo_idx % (md_->fifo_size)]);
+
+            return segment_md_;
+        }
 
         private:
         /**

--- a/include/daoShm.hpp
+++ b/include/daoShm.hpp
@@ -92,7 +92,7 @@ namespace Dao
         }
 
         /**
-         * @brief Retrieve a pointer to the shared memory frame array.
+         * @brief Retrieve a pointer to the newest segment of the shared memory frame array.
          * Optionally blocks until the next frame is written to shared memory.
          * @param sync Synchronization option (see Dao::ShmSync).
          * @return Pointer to the shared memory frame array, or nullptr if synchronization
@@ -113,7 +113,13 @@ namespace Dao
                         return nullptr;
                 } break;
             }
-            return (T*)image_.array.V;
+
+            void *newest_data;
+            uint32_t segment_idx;
+            uint64_t segment_cnt0;
+            daoShmGetNewestSegment(&image_, &newest_data, &segment_idx, &segment_cnt0);
+
+            return (T*)newest_data;
         }
 
         /**
@@ -224,11 +230,10 @@ namespace Dao
         T* get_arbitrary_frame(uint32_t segment_idx) {
             // Get the next frame
             void *segment_ptr;
-            uint64_t *segment_cnt0;
 
             daoShmGetArbitrarySegment(&image_, &segment_ptr, segment_idx);
 
-            return segment_ptr;
+            return (T*)segment_ptr;
         }
 
         /**

--- a/include/daoShm.hpp
+++ b/include/daoShm.hpp
@@ -334,7 +334,7 @@ namespace Dao
         IMAGE_METADATA* get_meta_data(uint32_t fifo_idx) const {
             volatile IMAGE_METADATA *segment_md_ = &(md_[fifo_idx % (md_->fifo_size)]);
 
-            return segment_md_;
+            return const_cast<IMAGE_METADATA*>(segment_md_);
         }
 
         private:

--- a/include/daoShm.hpp
+++ b/include/daoShm.hpp
@@ -160,12 +160,13 @@ namespace Dao
          * @return Pointer to the shared memory frame array, or nullptr if synchronization failed (wait enabled),
          * or if frame is not yet ready (wait disabled)
          */
-        T* get_next_frame(bool wait, uint_fast8_t &status) {
+        T* get_next_frame(bool wait, int_fast8_t &status) {
             // Wait for the next frame if requested
             if (wait) {
-                if (daoShmWaitForNextSegment(&image_) != DAO_SUCCESS)
+                if (daoShmWaitForNextSegment(&image_) != DAO_SUCCESS) {
                     status = DAO_ERROR;
                     return nullptr;
+                }
             }
 
             // Get the next frame
@@ -187,12 +188,13 @@ namespace Dao
          * @return Pointer to the shared memory frame array, or nullptr if either synchronization
          * failed (wait enabled), or if frame is not yet ready (wait disabled)
          */
-        T* get_next_frame(bool wait, uint_fast8_t &status, uint64_t &segment_cnt0) {
+        T* get_next_frame(bool wait, int_fast8_t &status, uint64_t &segment_cnt0) {
             // Wait for the next frame if requested
             if (wait) {
-                if (daoShmWaitForNextSegment(&image_) != DAO_SUCCESS)
+                if (daoShmWaitForNextSegment(&image_) != DAO_SUCCESS) {
                     status = DAO_ERROR;
                     return nullptr;
+                }
             }
 
             // Get the next frame
@@ -208,7 +210,7 @@ namespace Dao
          * @brief Check if the last frame read from the FIFO has been overwritten.
          * @return Status code, either DAO_SUCCESS if not overwritten, or DAO_OVERWRITE otherwise.
          */
-        uint_fast8_t check_segment_overwrite() {
+        int_fast8_t check_segment_overwrite() {
             return daoShmCheckSegmentOverwrite(&image_);
         }
 
@@ -312,7 +314,9 @@ namespace Dao
          * @return Seconds since Unix epoch.
          */
         int64_t get_timestamp(uint32_t fifo_idx) const {
-            return md_->atime.tsfixed.secondlong;
+            volatile IMAGE_METADATA *segment_md_ = &(md_[fifo_idx % (md_->fifo_size)]);
+
+            return segment_md_->atime.tsfixed.secondlong;
         }
 
         /**

--- a/include/daoShm.hpp
+++ b/include/daoShm.hpp
@@ -156,7 +156,7 @@ namespace Dao
          * @brief Retrieve a pointer to the next segment of the shared memory frame array.
          * Optionally blocks until the next frame is written to shared memory.
          * @param bool Flag to enable spinning until new frame is ready
-         * @param overwrite Reference to flag indicating frame overwrite (optional)
+         * @param status Reference to variable for holding status information
          * @return Pointer to the shared memory frame array, or nullptr if synchronization failed (wait enabled),
          * or if frame is not yet ready (wait disabled)
          */
@@ -176,6 +176,40 @@ namespace Dao
             status = daoShmGetNextSegment(&image_, &segment_ptr, &segment_idx, &segment_cnt0);
 
             return (T*)segment_ptr;
+        }
+
+        /**
+         * @brief Retrieve a pointer to the next segment of the shared memory frame array.
+         * Optionally blocks until the next frame is written to shared memory.
+         * @param bool Flag to enable spinning until new frame is ready
+         * @param status Reference to variable for holding status information
+         * @param segment_cnt0 CNT0 value of the segment at the time of reading
+         * @return Pointer to the shared memory frame array, or nullptr if either synchronization
+         * failed (wait enabled), or if frame is not yet ready (wait disabled)
+         */
+        T* get_next_frame(bool wait, uint_fast8_t &status, uint64_t &segment_cnt0) {
+            // Wait for the next frame if requested
+            if (wait) {
+                if (daoShmWaitForNextSegment(&image_) != DAO_SUCCESS)
+                    status = DAO_ERROR;
+                    return nullptr;
+            }
+
+            // Get the next frame
+            void *segment_ptr;
+            uint32_t segment_idx;
+
+            status = daoShmGetNextSegment(&image_, &segment_ptr, &segment_idx, &segment_cnt0);
+
+            return (T*)segment_ptr;
+        }
+
+        /**
+         * @brief Check if the last frame read from the FIFO has been overwritten.
+         * @return Status code, either DAO_SUCCESS if not overwritten, or DAO_OVERWRITE otherwise.
+         */
+        uint_fast8_t check_segment_overwrite() {
+            return daoShmCheckSegmentOverwrite(&image_);
         }
 
         /**

--- a/src/c/dao.c
+++ b/src/c/dao.c
@@ -2042,9 +2042,7 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
         volatile IMAGE_METADATA *reading_md = (volatile IMAGE_METADATA *)imageCube[k]->md;
 
         uint32_t last_written = reading_md[0].fifo_last_written;
-        uint32_t writing_idx = (last_written + 1) % (imageCube[k]->md[0].fifo_size);
-
-        fifo_reading_offset[k] = imageCube[k]->md[0].nelement * (uint64_t)writing_idx;
+        fifo_reading_offset[k] = imageCube[k]->md[0].nelement * (uint64_t)last_written;
     }
     
     // check type and use proper array

--- a/src/c/dao.c
+++ b/src/c/dao.c
@@ -899,9 +899,9 @@ int_fast8_t daoShmImage2Shm(void *im, uint32_t nbVal, IMAGE *image)
         memcpy(&image->array.UI16[fifo_writing_offset], (unsigned short *)im, nbVal*sizeof(unsigned short));
     else if (image->md[writing_idx].atype == _DATATYPE_INT16)
         memcpy(&image->array.SI16[fifo_writing_offset], (short *)im, nbVal*sizeof(short));
-    else if (image->md[writing_idx].atype == _DATATYPE_INT32)
-        memcpy(&image->array.UI32[fifo_writing_offset], (unsigned int *)im, nbVal*sizeof(unsigned int));
     else if (image->md[writing_idx].atype == _DATATYPE_UINT32)
+        memcpy(&image->array.UI32[fifo_writing_offset], (unsigned int *)im, nbVal*sizeof(unsigned int));
+    else if (image->md[writing_idx].atype == _DATATYPE_INT32)
         memcpy(&image->array.SI32[fifo_writing_offset], (int *)im, nbVal*sizeof(int));
     else if (image->md[writing_idx].atype == _DATATYPE_UINT64)
         memcpy(&image->array.UI64[fifo_writing_offset], (unsigned long *)im, nbVal*sizeof(unsigned long));
@@ -945,9 +945,9 @@ int_fast8_t daoShmImage2ShmQuiet(void *im, uint32_t nbVal, IMAGE *image)
         memcpy(&image->array.UI16[fifo_writing_offset], (unsigned short *)im, nbVal*sizeof(unsigned short));
     else if (image->md[0].atype == _DATATYPE_INT16)
         memcpy(&image->array.SI16[fifo_writing_offset], (short *)im, nbVal*sizeof(short));
-    else if (image->md[0].atype == _DATATYPE_INT32)
-        memcpy(&image->array.UI32[fifo_writing_offset], (unsigned int *)im, nbVal*sizeof(unsigned int));
     else if (image->md[0].atype == _DATATYPE_UINT32)
+        memcpy(&image->array.UI32[fifo_writing_offset], (unsigned int *)im, nbVal*sizeof(unsigned int));
+    else if (image->md[0].atype == _DATATYPE_INT32)
         memcpy(&image->array.SI32[fifo_writing_offset], (int *)im, nbVal*sizeof(int));
     else if (image->md[0].atype == _DATATYPE_UINT64)
         memcpy(&image->array.UI64[fifo_writing_offset], (unsigned long *)im, nbVal*sizeof(unsigned long));
@@ -995,9 +995,9 @@ int_fast8_t daoShmImagePart2Shm(char *im, uint32_t nbVal, IMAGE *image, uint32_t
         memcpy(&image->array.UI16[adjusted_position], (unsigned short *)im, nbVal*sizeof(unsigned short));
     else if (image->md[0].atype == _DATATYPE_INT16)
         memcpy(&image->array.SI16[adjusted_position], (short *)im, nbVal*sizeof(short));
-    else if (image->md[0].atype == _DATATYPE_INT32)
-        memcpy(&image->array.UI32[adjusted_position], (unsigned int *)im, nbVal*sizeof(unsigned int));
     else if (image->md[0].atype == _DATATYPE_UINT32)
+        memcpy(&image->array.UI32[adjusted_position], (unsigned int *)im, nbVal*sizeof(unsigned int));
+    else if (image->md[0].atype == _DATATYPE_INT32)
         memcpy(&image->array.SI32[adjusted_position], (int *)im, nbVal*sizeof(int));
     else if (image->md[0].atype == _DATATYPE_UINT64)
         memcpy(&image->array.UI64[adjusted_position], (unsigned long *)im, nbVal*sizeof(unsigned long));
@@ -2581,9 +2581,9 @@ int_fast8_t daoShmGetNextSegment(IMAGE *image, void** segment_ptr, uint32_t* seg
         *segment_ptr = &(image->array.UI16[next_segment_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_INT16)
         *segment_ptr = &(image->array.SI16[next_segment_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_INT32)
-        *segment_ptr = &(image->array.UI32[next_segment_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_UINT32)
+        *segment_ptr = &(image->array.UI32[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT32)
         *segment_ptr = &(image->array.SI32[next_segment_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_UINT64)
         *segment_ptr = &(image->array.UI64[next_segment_idx * image->md[0].nelement]);
@@ -2639,9 +2639,9 @@ int_fast8_t daoShmGetArbitrarySegment(IMAGE *image, void** segment_ptr, uint_fas
         *segment_ptr = &(image->array.UI16[actual_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_INT16)
         *segment_ptr = &(image->array.SI16[actual_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_INT32)
-        *segment_ptr = &(image->array.UI32[actual_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_UINT32)
+        *segment_ptr = &(image->array.UI32[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT32)
         *segment_ptr = &(image->array.SI32[actual_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_UINT64)
         *segment_ptr = &(image->array.UI64[actual_idx * image->md[0].nelement]);
@@ -2682,9 +2682,9 @@ int_fast8_t daoShmGetNewestSegment(IMAGE *image, void** segment_ptr, uint32_t* s
         *segment_ptr = &(image->array.UI16[last_written * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_INT16)
         *segment_ptr = &(image->array.SI16[last_written * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_INT32)
-        *segment_ptr = &(image->array.UI32[last_written * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_UINT32)
+        *segment_ptr = &(image->array.UI32[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT32)
         *segment_ptr = &(image->array.SI32[last_written * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_UINT64)
         *segment_ptr = &(image->array.UI64[last_written * image->md[0].nelement]);

--- a/src/c/dao.c
+++ b/src/c/dao.c
@@ -2478,11 +2478,9 @@ int_fast8_t daoShmWaitForTargetCounter(IMAGE *image, uint64_t targetCnt0)
     req.tv_sec = 0;          // Seconds
     req.tv_nsec = 0; // Nanoseconds
 
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
-
-    if (vol_md->fifo_size == 1) // Spin on our only cnt0 for 1-deep images
+    if (md->fifo_size == 1) // Spin on our only cnt0 for 1-deep images
     {
-        while (vol_md->cnt0 < targetCnt0)
+        while (md->cnt0 < targetCnt0)
         {
             // Spin
             if (nanosleep(&req, &rem) < 0) 
@@ -2497,9 +2495,9 @@ int_fast8_t daoShmWaitForTargetCounter(IMAGE *image, uint64_t targetCnt0)
         while (1)
         {
             // Check counter of last position
-            uint32_t fifo_last_written = vol_md[0].fifo_last_written;
+            uint32_t fifo_last_written = md[0].fifo_last_written;
 
-            if (vol_md[fifo_last_written].cnt0 >= targetCnt0)
+            if (md[fifo_last_written].cnt0 >= targetCnt0)
                 break;
 
             // Spin

--- a/src/c/dao.c
+++ b/src/c/dao.c
@@ -2393,6 +2393,213 @@ uint_fast64_t daoShmGetCounter(IMAGE *image)
 }
 
 /**
+ * @brief Get the next segment of this shared memory, or the newest if our tail position has been lapped.
+ * 
+ * @param image 
+ * @param segmentPtr Pointer to start of the next segment's array
+ * @param segmentIdx Numerical index of the next segment
+ * @return int_fast8_t DAO_OVERWRITE if tail has been lapped, otherwise DAO_SUCCESS
+ */
+int_fast8_t daoShmGetNextSegment(IMAGE *image, void** segmentPtr, uint32_t* segmentIdx)
+{
+    // Pseudocode
+    // 1. get last_read_idx from IMAGE
+    // 3. increment last_read_idx next segment
+    // 4. get cnt0 from next segment
+    // 5. if next segment_cnt0 != last_read_cnt0 + 1, we have been lapped, so reset tail
+    // 6. set segmentPtr and segmentIdx with last_read_idx
+    // 2. set to last_read_idx 
+    // 7. return DAO_OVERWRITE if lapped, DAO_SUCCESS otherwise
+
+    int_fast8_t return_val = DAO_SUCCESS;
+
+    volatile IMAGE *vol_image = (volatile IMAGE *)image;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+
+    uint32_t last_read_idx  = vol_image->fifo_last_read;
+    uint64_t last_read_cnt0 = vol_image->fifo_last_read_cnt0;
+
+    // 2. increment last_read_idx to next segment
+    uint32_t next_segment_idx = (last_read_idx + 1) % vol_md[0].fifo_size;
+    uint64_t next_segment_cnt0 = last_read_cnt0 + 1;
+
+    if (vol_md[next_segment_idx].cnt0 != next_segment_cnt0)
+    { // We have been lapped by the writer. Set our position to the newest segment and signal the overwrite condition
+        return_val = DAO_OVERWRITE;
+        next_segment_idx = vol_md[0].fifo_last_written;
+        next_segment_cnt0 = vol_md[next_segment_idx].cnt0;
+    }
+
+    // Set the segment pointer and index
+    if (image->md[0].atype == _DATATYPE_UINT8)
+        *segmentPtr = &(image->array.UI8[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT8)
+        *segmentPtr = &(image->array.SI8[next_segment_idx * image->md[0].nelement]);      
+    else if (image->md[0].atype == _DATATYPE_UINT16)
+        *segmentPtr = &(image->array.UI16[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT16)
+        *segmentPtr = &(image->array.SI16[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT32)
+        *segmentPtr = &(image->array.UI32[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_UINT32)
+        *segmentPtr = &(image->array.SI32[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_UINT64)
+        *segmentPtr = &(image->array.UI64[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT64)
+        *segmentPtr = &(image->array.SI64[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_FLOAT)
+        *segmentPtr = &(image->array.F[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_DOUBLE)
+        *segmentPtr = &(image->array.D[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
+        *segmentPtr = &(image->array.CF[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
+        *segmentPtr = &(image->array.CD[next_segment_idx * image->md[0].nelement]);
+
+    *segmentIdx = next_segment_idx;
+
+    // Update the bookkeeping variables for this FIFO tail our IMAGE struct
+    vol_image->fifo_last_read = next_segment_idx;
+    vol_image->fifo_last_read_cnt0 = next_segment_cnt0;
+
+    return return_val;
+}
+
+/**
+ * @brief Get the specified segment of this shared memory.
+ * 
+ * @param image 
+ * @param segmentPtr Pointer to start of the given segment's array
+ * @param segmentIdx Numerical index of the segment to get
+ * @return int_fast8_t
+ */
+int_fast8_t daoShmGetArbitrarySegment(IMAGE *image, void** segmentPtr, uint_fast32_t fifoIdx)
+{
+    uint32_t actual_idx = (uint32_t)(fifoIdx % image->md[0].fifo_size);
+
+    if (image->md[0].atype == _DATATYPE_UINT8)
+        *segmentPtr = &(image->array.UI8[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT8)
+        *segmentPtr = &(image->array.SI8[actual_idx * image->md[0].nelement]);      
+    else if (image->md[0].atype == _DATATYPE_UINT16)
+        *segmentPtr = &(image->array.UI16[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT16)
+        *segmentPtr = &(image->array.SI16[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT32)
+        *segmentPtr = &(image->array.UI32[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_UINT32)
+        *segmentPtr = &(image->array.SI32[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_UINT64)
+        *segmentPtr = &(image->array.UI64[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT64)
+        *segmentPtr = &(image->array.SI64[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_FLOAT)
+        *segmentPtr = &(image->array.F[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_DOUBLE)
+        *segmentPtr = &(image->array.D[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
+        *segmentPtr = &(image->array.CF[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
+        *segmentPtr = &(image->array.CD[actual_idx * image->md[0].nelement]);
+
+    return DAO_SUCCESS;
+}
+
+/**
+ * @brief Get the segment of this shared memory which was last written to.
+ * 
+ * @param image 
+ * @param segmentPtr Pointer to start of the newest segment's array
+ * @param segmentIdx Numerical index of the newest segment
+ * @return int_fast8_t
+ */
+int_fast8_t daoShmGetNewestSegment(IMAGE *image, void** segmentPtr, uint32_t* segment_idx)
+{
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+
+    uint32_t last_written = vol_md[0].fifo_last_written;
+
+    if (image->md[0].atype == _DATATYPE_UINT8)
+        *segmentPtr = &(image->array.UI8[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT8)
+        *segmentPtr = &(image->array.SI8[last_written * image->md[0].nelement]);      
+    else if (image->md[0].atype == _DATATYPE_UINT16)
+        *segmentPtr = &(image->array.UI16[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT16)
+        *segmentPtr = &(image->array.SI16[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT32)
+        *segmentPtr = &(image->array.UI32[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_UINT32)
+        *segmentPtr = &(image->array.SI32[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_UINT64)
+        *segmentPtr = &(image->array.UI64[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT64)
+        *segmentPtr = &(image->array.SI64[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_FLOAT)
+        *segmentPtr = &(image->array.F[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_DOUBLE)
+        *segmentPtr = &(image->array.D[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
+        *segmentPtr = &(image->array.CF[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
+        *segmentPtr = &(image->array.CD[last_written * image->md[0].nelement]);
+
+    *segment_idx = last_written;
+
+    return DAO_SUCCESS;
+}
+
+/**
+ * @brief Indicates if the segment was overwritten since it was last inspected
+ * 
+ * @param image 
+ * @return int_fast8_t DAO_OVERWRITE if segment was overwritten, DAO_SUCCESS otherwise
+ */
+int_fast8_t daoShmCheckSegmentOverwrite(IMAGE *image)
+{
+    // Pseudocode
+    // 1. get last read CNT0 from IMAGE
+    // 2. get new value of CNT0 for this segment from IMAGE_METADATA
+    // 3. Check if new_value == last read, or if write flag is set
+    // 4. return accordingly
+
+    int_fast8_t return_val = DAO_SUCCESS;
+
+    volatile IMAGE *vol_image = (volatile IMAGE *)image;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+
+    uint32_t last_read_idx = vol_image->fifo_last_read;
+    uint64_t last_read_cnt0 = vol_image->fifo_last_read_cnt0;
+
+    if (vol_md[last_read_idx].write == 1 || vol_md[last_read_idx].cnt0 != last_read_cnt0)
+    {
+        return_val = DAO_OVERWRITE;
+    }
+
+    return return_val;
+}
+
+/**
+ * @brief Reset the reading tail on this SHM image struct to the current newest segment.
+ * 
+ * @param image 
+ * @param segmentIdx Index to which the tail was reset
+ * @return int_fast8_t
+ */
+int_fast8_t daoShmResetTail(IMAGE *image, uint32_t* segmentIdx)
+{
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+
+    uint32_t new_segment_idx = vol_md[0].fifo_last_written;
+
+    *segmentIdx = new_segment_idx;
+    image->fifo_last_read = new_segment_idx;
+
+    return DAO_SUCCESS;
+}
+
+
+/**
  * Clean up shared memory resources
  * 
  * Properly closes file descriptors, unmaps memory, and releases semaphores
@@ -2485,7 +2692,7 @@ int_fast8_t daoShmCloseShm(IMAGE *image)
 }
 
 /**
- * @brief Time stamp an image
+ * @brief Time stamp the most recently written segment of the image
  * 
  * @param image 
  * @return int_fast8_t 
@@ -2494,8 +2701,11 @@ int_fast8_t daoShmTimestampShm(IMAGE *image)
 {
     struct timespec t;
     clock_gettime(CLOCK_REALTIME, &t);
-    image->md[0].atime.tsfixed.secondlong = ((int64_t)(1e9 * t.tv_sec) + t.tv_nsec);
-    image->md[0].cnt0++;
+
+    uint32_t fifo_last_written = image->md[0].fifo_last_written;
+
+    image->md[fifo_last_written].atime.tsfixed.secondlong = ((int64_t)(1e9 * t.tv_sec) + t.tv_nsec);
+    image->md[fifo_last_written].cnt0++;
 
     return DAO_SUCCESS;
 }

--- a/src/c/dao.c
+++ b/src/c/dao.c
@@ -475,6 +475,8 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
     long snb;
     long s;
 
+    uint32_t fifo_size;
+
 #ifdef _WIN32
     HANDLE shmFd; // shared memory file handle
 	HANDLE shmFm; // shared memory file mapping object
@@ -590,8 +592,12 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
             exit(0);
         }
 
+        /* Get the size of the FIFO */
+
+        fifo_size = image->md[0].fifo_size;
+
         mapv = (char*) map;
-        mapv += sizeof(IMAGE_METADATA);
+        mapv += fifo_size * sizeof(IMAGE_METADATA);
 
         daoDebug("atype = %d\n", (int) atype);
         fflush(stdout);
@@ -600,73 +606,73 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
         {
             daoDebug("atype = UINT8\n");
             image->array.UI8 = (uint8_t*) mapv;
-            mapv += SIZEOF_DATATYPE_UINT8 * image->md[0].nelement;
+            mapv += SIZEOF_DATATYPE_UINT8 * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_INT8)
         {
             daoDebug("atype = INT8\n");
             image->array.SI8 = (int8_t*) mapv;
-            mapv += SIZEOF_DATATYPE_INT8 * image->md[0].nelement;
+            mapv += SIZEOF_DATATYPE_INT8 * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_UINT16)
         {
             daoDebug("atype = UINT16\n");
             image->array.UI16 = (uint16_t*) mapv;
-            mapv += SIZEOF_DATATYPE_UINT16 * image->md[0].nelement;
+            mapv += SIZEOF_DATATYPE_UINT16 * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_INT16)
         {
             daoDebug("atype = INT16\n");
             image->array.SI16 = (int16_t*) mapv;
-            mapv += SIZEOF_DATATYPE_INT16 * image->md[0].nelement;
+            mapv += SIZEOF_DATATYPE_INT16 * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_UINT32)
         {
             daoDebug("atype = UINT32\n");
             image->array.UI32 = (uint32_t*) mapv;
-            mapv += SIZEOF_DATATYPE_UINT32 * image->md[0].nelement;
+            mapv += SIZEOF_DATATYPE_UINT32 * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_INT32)
         {
             daoDebug("atype = INT32\n");
             image->array.SI32 = (int32_t*) mapv;
-            mapv += SIZEOF_DATATYPE_INT32 * image->md[0].nelement;
+            mapv += SIZEOF_DATATYPE_INT32 * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_UINT64)
         {
             daoDebug("atype = UINT64\n");
             image->array.UI64 = (uint64_t*) mapv;
-            mapv += SIZEOF_DATATYPE_UINT64 * image->md[0].nelement;
+            mapv += SIZEOF_DATATYPE_UINT64 * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_INT64)
         {
             daoDebug("atype = INT64\n");
             image->array.SI64 = (int64_t*) mapv;
-            mapv += SIZEOF_DATATYPE_INT64 * image->md[0].nelement;
+            mapv += SIZEOF_DATATYPE_INT64 * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_FLOAT)
         {
             daoDebug("atype = FLOAT\n");
             image->array.F = (float*) mapv;
-            mapv += SIZEOF_DATATYPE_FLOAT * image->md[0].nelement;
+            mapv += SIZEOF_DATATYPE_FLOAT * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_DOUBLE)
         {
             daoDebug("atype = DOUBLE\n");
             image->array.D = (double*) mapv;
-            mapv += SIZEOF_DATATYPE_DOUBLE * image->md[0].nelement;
+            mapv += SIZEOF_DATATYPE_DOUBLE * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_COMPLEX_FLOAT)
         {
             daoDebug("atype = COMPLEX_FLOAT\n");
             image->array.CF = (complex_float*) mapv;
-            mapv += SIZEOF_DATATYPE_COMPLEX_FLOAT * image->md[0].nelement;
+            mapv += SIZEOF_DATATYPE_COMPLEX_FLOAT * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_COMPLEX_DOUBLE)
         {
             daoDebug("atype = COMPLEX_DOUBLE\n");
             image->array.CD = (complex_double*) mapv;
-            mapv += SIZEOF_DATATYPE_COMPLEX_DOUBLE * image->md[0].nelement;
+            mapv += SIZEOF_DATATYPE_COMPLEX_DOUBLE * fifo_size * image->md[0].nelement;
         }
         daoDebug("%ld keywords\n", (long) image->md[0].NBkw);
         fflush(stdout);
@@ -1180,8 +1186,8 @@ int_fast8_t daoImageCreateSem(IMAGE *image, long NBsem)
 /*
  * Create SHM
  */
-int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis, 
-                              uint32_t *size, uint8_t atype, int shared, int NBkw)
+int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis, 
+                              uint32_t *size, uint8_t atype, int shared, int NBkw, uint32_t fifo_size)
 {
     daoTrace("\n");
     long i;//,ii;
@@ -1289,58 +1295,61 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         }
 #endif
 
-        sharedsize = sizeof(IMAGE_METADATA);
+        /* First, determine the space requirements for storing all copies of the image metadata */
+        sharedsize = fifo_size * sizeof(IMAGE_METADATA);
 
+        /* Now add the space requirements for the buffers themselves */
         if(atype == _DATATYPE_UINT8)
         {
-            sharedsize += nelement*SIZEOF_DATATYPE_UINT8;
+            sharedsize += fifo_size * nelement * SIZEOF_DATATYPE_UINT8;
         }
         if(atype == _DATATYPE_INT8)
         {
-            sharedsize += nelement*SIZEOF_DATATYPE_INT8;
+            sharedsize += fifo_size * nelement * SIZEOF_DATATYPE_INT8;
         }
         if(atype == _DATATYPE_UINT16)
         {
-            sharedsize += nelement*SIZEOF_DATATYPE_UINT16;
+            sharedsize += fifo_size * nelement * SIZEOF_DATATYPE_UINT16;
         }
         if(atype == _DATATYPE_INT16)
         {
-            sharedsize += nelement*SIZEOF_DATATYPE_INT16;
+            sharedsize += fifo_size * nelement * SIZEOF_DATATYPE_INT16;
         }
         if(atype == _DATATYPE_INT32)
         {
-            sharedsize += nelement*SIZEOF_DATATYPE_INT32;
+            sharedsize += fifo_size * nelement * SIZEOF_DATATYPE_INT32;
         }
         if(atype == _DATATYPE_UINT32)
         {
-            sharedsize += nelement*SIZEOF_DATATYPE_UINT32;
+            sharedsize += fifo_size * nelement * SIZEOF_DATATYPE_UINT32;
         }
         if(atype == _DATATYPE_INT64)
         {
-            sharedsize += nelement*SIZEOF_DATATYPE_INT64;
+            sharedsize += fifo_size * nelement * SIZEOF_DATATYPE_INT64;
         }
         if(atype == _DATATYPE_UINT64)
         {
-            sharedsize += nelement*SIZEOF_DATATYPE_UINT64;
+            sharedsize += fifo_size * nelement * SIZEOF_DATATYPE_UINT64;
         }
         if(atype == _DATATYPE_FLOAT)
         {
-            sharedsize += nelement*SIZEOF_DATATYPE_FLOAT;
+            sharedsize += fifo_size * nelement * SIZEOF_DATATYPE_FLOAT;
         }
         if(atype == _DATATYPE_DOUBLE)
         {
-            sharedsize += nelement*SIZEOF_DATATYPE_DOUBLE;
+            sharedsize += fifo_size * nelement * SIZEOF_DATATYPE_DOUBLE;
         }
         if(atype == _DATATYPE_COMPLEX_FLOAT)
         {
-            sharedsize += nelement*SIZEOF_DATATYPE_COMPLEX_FLOAT;
+            sharedsize += fifo_size * nelement * SIZEOF_DATATYPE_COMPLEX_FLOAT;
         }
         if(atype == _DATATYPE_COMPLEX_DOUBLE)
         {
-            sharedsize += nelement*SIZEOF_DATATYPE_COMPLEX_DOUBLE;
+            sharedsize += fifo_size * nelement * SIZEOF_DATATYPE_COMPLEX_DOUBLE;
         }
 
-        sharedsize += NBkw*sizeof(IMAGE_KEYWORD);
+        /* And finally, set aside space for the keywords */
+        sharedsize += NBkw * sizeof(IMAGE_KEYWORD);
 
 #ifdef _WIN32
         sprintf(shmName, "%s", name);
@@ -1427,8 +1436,13 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
 #endif
 	
         image->md = (IMAGE_METADATA*) map;
-        image->md[0].shared = 1;
-        image->md[0].sem = 0;
+
+        for (uint32_t fifo_idx = 0; fifo_idx < fifo_size; ++fifo_idx)
+        {
+            image->md[fifo_idx].shared = 1;
+            image->md[fifo_idx].sem = 0;
+        }
+
         free(nameCopy);
 
 #ifdef _WIN32
@@ -1437,8 +1451,13 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
     }
     else
     {
-        image->md = (IMAGE_METADATA*) malloc(sizeof(IMAGE_METADATA));
-        image->md[0].shared = 0;
+        image->md = (IMAGE_METADATA*) malloc(sizeof(IMAGE_METADATA) * fifo_size);
+
+        for (uint32_t fifo_idx = 0; fifo_idx < fifo_size; ++fifo_idx)
+        {
+            image->md[fifo_idx].shared = 0;
+        }
+
         if(NBkw>0)
         {
             image->kw = (IMAGE_KEYWORD*) malloc(sizeof(IMAGE_KEYWORD)*NBkw);
@@ -1449,16 +1468,20 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         }
     }
 
-    image->md[0].atype = atype;
-    image->md[0].naxis = (uint8_t)naxis;
-
     strcpy(image->name, name); // local name
-    strcpy(image->md[0].name, name);
-    for(i=0; i<naxis; i++)
+    for (uint32_t fifo_idx = 0; fifo_idx < fifo_size; ++fifo_idx)
     {
-        image->md[0].size[i] = size[i];
+        image->md[fifo_idx].atype = atype;
+        image->md[fifo_idx].naxis = (uint8_t)naxis;
+
+        strcpy(image->md[fifo_idx].name, name);
+
+        for(i=0; i<naxis; i++)
+        {
+            image->md[fifo_idx].size[i] = size[i];
+        }
+        image->md[fifo_idx].NBkw = NBkw;
     }
-    image->md[0].NBkw = NBkw;
 
 
     if(atype == _DATATYPE_UINT8)
@@ -1466,7 +1489,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         if(shared==1)
         {
 			mapv = (char*) map;
-            mapv += sizeof(IMAGE_METADATA);
+            mapv += sizeof(IMAGE_METADATA) * fifo_size;
             image->array.UI8 = (uint8_t*) (mapv);
             memset(image->array.UI8, '\0', nelement*sizeof(uint8_t));
             mapv += sizeof(uint8_t)*nelement;
@@ -1474,7 +1497,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
 		}
         else
         {
-            image->array.UI8 = (uint8_t*) calloc ((size_t) nelement, sizeof(uint8_t));
+            image->array.UI8 = (uint8_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint8_t));
         }
 
 
@@ -1488,7 +1511,8 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
             for(i=1; i<naxis; i++)
                 fprintf(stderr,"x%ld", (long) size[i]);
             fprintf(stderr,"\n");
-            fprintf(stderr,"Requested memory size = %ld elements = %f Mb\n", (long) nelement,1.0/1024/1024*nelement*sizeof(uint8_t));
+            fprintf(stderr,"Requested memory size = %ld elements * %ld buffers = %f Mb\n",
+                (long) nelement, (long) fifo_size, 1.0/1024/1024*nelement*fifo_size*sizeof(uint8_t));
             fprintf(stderr," %c[%d;m",(char) 27, 0);
             exit(0);
         }
@@ -1499,14 +1523,14 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         if(shared==1)
         {
 			mapv = (char*) map;
-            mapv += sizeof(IMAGE_METADATA);
+            mapv += sizeof(IMAGE_METADATA) * fifo_size;
             image->array.SI8 = (int8_t*) (mapv);
             memset(image->array.SI8, '\0', nelement*sizeof(int8_t));
             mapv += sizeof(int8_t)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
 		}
         else
-            image->array.SI8 = (int8_t*) calloc ((size_t) nelement, sizeof(int8_t));
+            image->array.SI8 = (int8_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int8_t));
 
 
         if(image->array.SI8 == NULL)
@@ -1519,7 +1543,8 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
             for(i=1; i<naxis; i++)
                 fprintf(stderr,"x%ld", (long) size[i]);
             fprintf(stderr,"\n");
-            fprintf(stderr,"Requested memory size = %ld elements = %f Mb\n", (long) nelement,1.0/1024/1024*nelement*sizeof(int8_t));
+            fprintf(stderr,"Requested memory size = %ld elements * %ld buffers = %f Mb\n",
+                (long) nelement, (long) fifo_size, 1.0/1024/1024*nelement*fifo_size*sizeof(int8_t));
             fprintf(stderr," %c[%d;m",(char) 27, 0);
             exit(0);
         }
@@ -1532,7 +1557,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         if(shared==1)
         {
             mapv = (char*) map;
-            mapv += sizeof(IMAGE_METADATA);
+            mapv += sizeof(IMAGE_METADATA) * fifo_size;
             image->array.UI16 = (uint16_t*) (mapv);
             memset(image->array.UI16, '\0', nelement*sizeof(uint16_t));
             mapv += sizeof(uint16_t)*nelement;
@@ -1540,7 +1565,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         }
         else
         {
-            image->array.UI16 = (uint16_t*) calloc ((size_t) nelement, sizeof(uint16_t));
+            image->array.UI16 = (uint16_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint16_t));
         }
 
         if(image->array.UI16 == NULL)
@@ -1553,7 +1578,8 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
             for(i=1; i<naxis; i++)
                 fprintf(stderr,"x%ld", (long) size[i]);
             fprintf(stderr,"\n");
-            fprintf(stderr,"Requested memory size = %ld elements = %f Mb\n", (long) nelement, 1.0/1024/1024*nelement*sizeof(uint16_t));
+            fprintf(stderr,"Requested memory size = %ld elements * %ld buffers = %f Mb\n",
+                (long) nelement, (long) fifo_size, 1.0/1024/1024*nelement*fifo_size*sizeof(uint16_t));
             fprintf(stderr," %c[%d;m",(char) 27, 0);
             exit(0);
         }
@@ -1564,7 +1590,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         if(shared==1)
         {
             mapv = (char*) map;
-            mapv += sizeof(IMAGE_METADATA);
+            mapv += sizeof(IMAGE_METADATA) * fifo_size;
             image->array.SI16 = (int16_t*) (mapv);
             memset(image->array.SI16, '\0', nelement*sizeof(int16_t));
             mapv += sizeof(int16_t)*nelement;
@@ -1572,7 +1598,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         }
         else
         {
-            image->array.SI16 = (int16_t*) calloc ((size_t) nelement, sizeof(int16_t));
+            image->array.SI16 = (int16_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int16_t));
         }
 
         if(image->array.SI16 == NULL)
@@ -1587,7 +1613,8 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
                 fprintf(stderr,"x%ld", (long) size[i]);
             }
             fprintf(stderr,"\n");
-            fprintf(stderr,"Requested memory size = %ld elements = %f Mb\n", (long) nelement, 1.0/1024/1024*nelement*sizeof(int16_t));
+            fprintf(stderr,"Requested memory size = %ld elements * %ld buffers = %f Mb\n",
+                (long) nelement, (long) fifo_size, 1.0/1024/1024*nelement*fifo_size*sizeof(int16_t));
             fprintf(stderr," %c[%d;m",(char) 27, 0);
             exit(0);
         }
@@ -1599,7 +1626,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         if(shared==1)
         {
 			mapv = (char*) map;
-            mapv += sizeof(IMAGE_METADATA);
+            mapv += sizeof(IMAGE_METADATA) * fifo_size;
             image->array.UI32 = (uint32_t*) (mapv);
             memset(image->array.UI32, '\0', nelement*sizeof(uint32_t));
             mapv += sizeof(uint32_t)*nelement;
@@ -1607,7 +1634,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         }
         else
         {
-            image->array.UI32 = (uint32_t*) calloc ((size_t) nelement, sizeof(uint32_t));
+            image->array.UI32 = (uint32_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint32_t));
         }
 
         if(image->array.UI32 == NULL)
@@ -1622,7 +1649,8 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
                 fprintf(stderr,"x%ld", (long) size[i]);
             }
             fprintf(stderr,"\n");
-            fprintf(stderr,"Requested memory size = %ld elements = %f Mb\n", (long) nelement,1.0/1024/1024*nelement*sizeof(uint32_t));
+            fprintf(stderr,"Requested memory size = %ld elements * %ld buffers = %f Mb\n",
+                (long) nelement, (long) fifo_size, 1.0/1024/1024*nelement*fifo_size*sizeof(uint32_t));
             fprintf(stderr," %c[%d;m",(char) 27, 0);
             exit(0);
         }
@@ -1635,7 +1663,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         if(shared==1)
         {
 			mapv = (char*) map;
-            mapv += sizeof(IMAGE_METADATA);
+            mapv += sizeof(IMAGE_METADATA) * fifo_size;
             image->array.SI32 = (int32_t*) (mapv);
             memset(image->array.SI32, '\0', nelement*sizeof(int32_t));
             mapv += sizeof(int32_t)*nelement;
@@ -1643,7 +1671,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         }
         else
         {
-            image->array.SI32 = (int32_t*) calloc ((size_t) nelement, sizeof(int32_t));
+            image->array.SI32 = (int32_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int32_t));
         }
 
         if(image->array.SI32 == NULL)
@@ -1658,7 +1686,8 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
                 fprintf(stderr,"x%ld", (long) size[i]);
             }
             fprintf(stderr,"\n");
-            fprintf(stderr,"Requested memory size = %ld elements = %f Mb\n", (long) nelement,1.0/1024/1024*nelement*sizeof(int32_t));
+            fprintf(stderr,"Requested memory size = %ld elements * %ld buffers = %f Mb\n",
+                (long) nelement, (long) fifo_size, 1.0/1024/1024*nelement*fifo_size*sizeof(int32_t));
             fprintf(stderr," %c[%d;m",(char) 27, 0);
             exit(0);
         }
@@ -1671,7 +1700,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         if(shared==1)
         {
 			mapv = (char*) map;
-            mapv += sizeof(IMAGE_METADATA);
+            mapv += sizeof(IMAGE_METADATA) * fifo_size;
             image->array.UI64 = (uint64_t*) (mapv);
             memset(image->array.UI64, '\0', nelement*sizeof(uint64_t));
             mapv += sizeof(uint64_t)*nelement;
@@ -1679,7 +1708,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         }
         else
         {
-            image->array.UI64 = (uint64_t*) calloc ((size_t) nelement, sizeof(uint64_t));
+            image->array.UI64 = (uint64_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint64_t));
         }
 
         if(image->array.SI64 == NULL)
@@ -1694,7 +1723,8 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
                 fprintf(stderr,"x%ld", (long) size[i]);
             }
             fprintf(stderr,"\n");
-            fprintf(stderr,"Requested memory size = %ld elements = %f Mb\n", (long) nelement,1.0/1024/1024*nelement*sizeof(uint64_t));
+            fprintf(stderr,"Requested memory size = %ld elements * %ld buffers = %f Mb\n",
+                (long) nelement, (long) fifo_size, 1.0/1024/1024*nelement*fifo_size*sizeof(uint64_t));
             fprintf(stderr," %c[%d;m",(char) 27, 0);
             exit(0);
         }
@@ -1705,7 +1735,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         if(shared==1)
         {
 			mapv = (char*) map;
-            mapv += sizeof(IMAGE_METADATA);
+            mapv += sizeof(IMAGE_METADATA) * fifo_size;
             image->array.SI64 = (int64_t*) (mapv);
             memset(image->array.SI64, '\0', nelement*sizeof(int64_t));
             mapv += sizeof(int64_t)*nelement;
@@ -1713,7 +1743,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         }
         else
         {
-            image->array.SI64 = (int64_t*) calloc ((size_t) nelement, sizeof(int64_t));
+            image->array.SI64 = (int64_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int64_t));
         }
 
         if(image->array.SI64 == NULL)
@@ -1728,7 +1758,8 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
                 fprintf(stderr,"x%ld", (long) size[i]);
             }
             fprintf(stderr,"\n");
-            fprintf(stderr,"Requested memory size = %ld elements = %f Mb\n", (long) nelement,1.0/1024/1024*nelement*sizeof(int64_t));
+            fprintf(stderr,"Requested memory size = %ld elements * %ld buffers = %f Mb\n",
+                (long) nelement, (long) fifo_size, 1.0/1024/1024*nelement*fifo_size*sizeof(int64_t));
             fprintf(stderr," %c[%d;m",(char) 27, 0);
             exit(0);
         }
@@ -1740,7 +1771,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         if(shared==1)
         {
             mapv = (char*) map;
-            mapv += sizeof(IMAGE_METADATA);
+            mapv += sizeof(IMAGE_METADATA) * fifo_size;
             image->array.F = (float*) (mapv);
             memset(image->array.F, '\0', nelement*sizeof(float));
             mapv += sizeof(float)*nelement;
@@ -1748,7 +1779,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         }
         else
         {
-            image->array.F = (float*) calloc ((size_t) nelement, sizeof(float));
+            image->array.F = (float*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(float));
         }
 
         if(image->array.F == NULL)
@@ -1763,7 +1794,8 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
                 fprintf(stderr,"x%ld", (long) size[i]);
             }
             fprintf(stderr,"\n");
-            fprintf(stderr,"Requested memory size = %ld elements = %f Mb\n", (long) nelement,1.0/1024/1024*nelement*sizeof(float));
+            fprintf(stderr,"Requested memory size = %ld elements * %ld buffers = %f Mb\n",
+                (long) nelement, (long) fifo_size, 1.0/1024/1024*nelement*fifo_size*sizeof(float));
             fprintf(stderr," %c[%d;m",(char) 27, 0);
             exit(0);
         }
@@ -1774,7 +1806,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         if(shared==1)
         {
 			mapv = (char*) map;
-			mapv += sizeof(IMAGE_METADATA);
+			mapv += sizeof(IMAGE_METADATA) * fifo_size;
 			image->array.D = (double*) (mapv);
             memset(image->array.D, '\0', nelement*sizeof(double));
             mapv += sizeof(double)*nelement;
@@ -1782,7 +1814,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         }
         else
         {
-            image->array.D = (double*) calloc ((size_t) nelement, sizeof(double));
+            image->array.D = (double*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(double));
         }
   
         if(image->array.D == NULL)
@@ -1797,7 +1829,8 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
                 fprintf(stderr,"x%ld", (long) size[i]);
             }
             fprintf(stderr,"\n");
-            fprintf(stderr,"Requested memory size = %ld elements = %f Mb\n", (long) nelement,1.0/1024/1024*nelement*sizeof(double));
+            fprintf(stderr,"Requested memory size = %ld elements * %ld buffers = %f Mb\n",
+                (long) nelement, (long) fifo_size, 1.0/1024/1024*nelement*fifo_size*sizeof(double));
             fprintf(stderr," %c[%d;m",(char) 27, 0);
             exit(0);
         }
@@ -1808,7 +1841,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         if(shared==1)
         {
 			mapv = (char*) map;
-			mapv += sizeof(IMAGE_METADATA);
+			mapv += sizeof(IMAGE_METADATA) * fifo_size;
 			image->array.CF = (complex_float*) (mapv);			
             memset(image->array.CF, '\0', nelement*sizeof(complex_float));
             mapv += sizeof(complex_float)*nelement;
@@ -1816,7 +1849,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         }
         else
         {
-            image->array.CF = (complex_float*) calloc ((size_t) nelement, sizeof(complex_float));
+            image->array.CF = (complex_float*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(complex_float));
         }
 
         if(image->array.CF == NULL)
@@ -1831,7 +1864,8 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
                 fprintf(stderr,"x%ld", (long) size[i]);
             }
             fprintf(stderr,"\n");
-            fprintf(stderr,"Requested memory size = %ld elements = %f Mb\n", (long) nelement,1.0/1024/1024*nelement*sizeof(complex_float));
+            fprintf(stderr,"Requested memory size = %ld elements * %ld buffers = %f Mb\n",
+                (long) nelement, (long) fifo_size, 1.0/1024/1024*nelement*fifo_size*sizeof(complex_float));
             fprintf(stderr," %c[%d;m",(char) 27, 0);
             exit(0);
         }
@@ -1842,7 +1876,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         if(shared==1)
         {
 			mapv = (char*) map;
-			mapv += sizeof(IMAGE_METADATA);
+			mapv += sizeof(IMAGE_METADATA) * fifo_size;
 			image->array.CD = (complex_double*) (mapv);			
             memset(image->array.CD, '\0', nelement*sizeof(complex_double));
             mapv += sizeof(complex_double)*nelement;
@@ -1850,7 +1884,7 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
         }
         else
         {
-            image->array.CD = (complex_double*) calloc ((size_t) nelement,sizeof(complex_double));
+            image->array.CD = (complex_double*) calloc ((size_t) nelement * (size_t) fifo_size,sizeof(complex_double));
         }
 
         if(image->array.CD == NULL)
@@ -1865,19 +1899,24 @@ int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis,
                 fprintf(stderr,"x%ld", (long) size[i]);
             }
             fprintf(stderr,"\n");
-            fprintf(stderr,"Requested memory size = %ld elements = %f Mb\n", (long) nelement,1.0/1024/1024*nelement*sizeof(complex_double));
+            fprintf(stderr,"Requested memory size = %ld elements * %ld buffers = %f Mb\n",
+                (long) nelement, (long) fifo_size, 1.0/1024/1024*nelement*fifo_size*sizeof(complex_double));
             fprintf(stderr," %c[%d;m",(char) 27, 0);
             exit(0);
         }
     }
 
     clock_gettime(CLOCK_REALTIME, &timenow);
-    image->md[0].last_access = 1.0*timenow.tv_sec + 0.000000001*timenow.tv_nsec;
-    image->md[0].creation_time = image->md[0].last_access;
-    image->md[0].write = 0;
-    image->md[0].cnt0 = 0;
-    image->md[0].cnt1 = 0;
-    image->md[0].nelement = nelement;
+
+    for (uint32_t fifo_idx = 0; fifo_idx < fifo_size; ++fifo_idx)
+    {
+        image->md[fifo_idx].last_access = 1.0*timenow.tv_sec + 0.000000001*timenow.tv_nsec;
+        image->md[fifo_idx].creation_time = image->md[0].last_access;
+        image->md[fifo_idx].write = 0;
+        image->md[fifo_idx].cnt0 = 0;
+        image->md[fifo_idx].cnt1 = 0;
+        image->md[fifo_idx].nelement = nelement;
+    }
 
     if(shared==1)
     {
@@ -2059,6 +2098,13 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
     daoShmImagePart2ShmFinalize(image);
 
     return DAO_SUCCESS;
+}
+
+/* Function for compatibility - creates 1-deep DAO SHM */
+int_fast8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis, 
+                              uint32_t *size, uint8_t atype, int shared, int NBkw)
+{
+    return daoShmImageCreate_FIFO(image, name, naxis, size, atype, shared, NBkw, 1);
 }
 
 /**

--- a/src/c/dao.c
+++ b/src/c/dao.c
@@ -2004,17 +2004,25 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
     daoTrace("\n");
     int pp;
     int k;
-    image->md[0].write = 1;
+
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+
+    uint32_t last_written = vol_md[0].fifo_last_written;
+    uint32_t writing_idx = (last_written + 1) % (image->md[0].fifo_size);
+
+    uint64_t fifo_writing_offset = image->md[0].nelement * (uint64_t)writing_idx;
+
+    vol_md[writing_idx].write = 1;
     
     // check type and use proper array
     if (image->md[0].atype == _DATATYPE_UINT8)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.UI8[pp] = 0;
+            image[0].array.UI8[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.UI8[pp] += imageCube[k][0].array.UI8[pp];
+                image[0].array.UI8[fifo_writing_offset + pp] += imageCube[k][0].array.UI8[pp];
             }
         }
     }
@@ -2022,10 +2030,10 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.SI8[pp] = 0;
+            image[0].array.SI8[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.SI8[pp] += imageCube[k][0].array.SI8[pp];
+                image[0].array.SI8[fifo_writing_offset + pp] += imageCube[k][0].array.SI8[pp];
             }
         }
     }
@@ -2033,10 +2041,10 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.UI16[pp] = 0;
+            image[0].array.UI16[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.UI16[pp] += imageCube[k][0].array.UI16[pp];
+                image[0].array.UI16[fifo_writing_offset + pp] += imageCube[k][0].array.UI16[pp];
             }
         }
     }
@@ -2044,10 +2052,10 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.SI16[pp] = 0;
+            image[0].array.SI16[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.SI16[pp] += imageCube[k][0].array.SI16[pp];
+                image[0].array.SI16[fifo_writing_offset + pp] += imageCube[k][0].array.SI16[pp];
             }
         }
     }
@@ -2055,10 +2063,10 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.UI32[pp] = 0;
+            image[0].array.UI32[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.UI32[pp] += imageCube[k][0].array.UI32[pp];
+                image[0].array.UI32[fifo_writing_offset + pp] += imageCube[k][0].array.UI32[pp];
             }
         }
     }
@@ -2066,10 +2074,10 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.SI32[pp] = 0;
+            image[0].array.SI32[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.SI32[pp] += imageCube[k][0].array.SI32[pp];
+                image[0].array.SI32[fifo_writing_offset + pp] += imageCube[k][0].array.SI32[pp];
             }
         }
     }
@@ -2077,10 +2085,10 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.UI64[pp] = 0;
+            image[0].array.UI64[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.UI64[pp] += imageCube[k][0].array.UI64[pp];
+                image[0].array.UI64[fifo_writing_offset + pp] += imageCube[k][0].array.UI64[pp];
             }
         }
     }
@@ -2088,10 +2096,10 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.SI64[pp] = 0;
+            image[0].array.SI64[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.SI64[pp] += imageCube[k][0].array.SI64[pp];
+                image[0].array.SI64[fifo_writing_offset + pp] += imageCube[k][0].array.SI64[pp];
             }
         }
     }
@@ -2099,10 +2107,10 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.F[pp] = 0;
+            image[0].array.F[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.F[pp] += imageCube[k][0].array.F[pp];
+                image[0].array.F[fifo_writing_offset + pp] += imageCube[k][0].array.F[pp];
             }
         }
     }
@@ -2110,10 +2118,10 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.D[pp] = 0;
+            image[0].array.D[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.D[pp] += imageCube[k][0].array.D[pp];
+                image[0].array.D[fifo_writing_offset + pp] += imageCube[k][0].array.D[pp];
             }
         }
     }
@@ -2121,12 +2129,12 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.CF[pp].re = 0;
-            image[0].array.CF[pp].im = 0;
+            image[0].array.CF[fifo_writing_offset + pp].re = 0;
+            image[0].array.CF[fifo_writing_offset + pp].im = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.CF[pp].re += imageCube[k][0].array.CF[pp].re;
-                image[0].array.CF[pp].im += imageCube[k][0].array.CF[pp].im;
+                image[0].array.CF[fifo_writing_offset + pp].re += imageCube[k][0].array.CF[pp].re;
+                image[0].array.CF[fifo_writing_offset + pp].im += imageCube[k][0].array.CF[pp].im;
             }
         }
     }
@@ -2134,12 +2142,12 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.CD[pp].re = 0;
-            image[0].array.CD[pp].im = 0;
+            image[0].array.CD[fifo_writing_offset + pp].re = 0;
+            image[0].array.CD[fifo_writing_offset + pp].im = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.CD[pp].re += imageCube[k][0].array.CD[pp].re;
-                image[0].array.CD[pp].im += imageCube[k][0].array.CD[pp].im;
+                image[0].array.CD[fifo_writing_offset + pp].re += imageCube[k][0].array.CD[pp].re;
+                image[0].array.CD[fifo_writing_offset + pp].im += imageCube[k][0].array.CD[pp].im;
             }
         }
     }

--- a/src/c/dao.c
+++ b/src/c/dao.c
@@ -875,32 +875,40 @@ int_fast8_t daoShmInit1D(const char *name, uint32_t nbVal, IMAGE **image)
 int_fast8_t daoShmImage2Shm(void *im, uint32_t nbVal, IMAGE *image) 
 {
     daoTrace("\n");
-    image->md[0].write = 1;
 
-    if (image->md[0].atype == _DATATYPE_UINT8)
-        memcpy(image->array.UI8, (unsigned char *)im, nbVal*sizeof(unsigned char)); 
-    else if (image->md[0].atype == _DATATYPE_INT8)
-        memcpy(image->array.SI8, (char *)im, nbVal*sizeof(char));       
-    else if (image->md[0].atype == _DATATYPE_UINT16)
-        memcpy(image->array.UI16, (unsigned short *)im, nbVal*sizeof(unsigned short));
-    else if (image->md[0].atype == _DATATYPE_INT16)
-        memcpy(image->array.SI16, (short *)im, nbVal*sizeof(short));
-    else if (image->md[0].atype == _DATATYPE_INT32)
-        memcpy(image->array.UI32, (unsigned int *)im, nbVal*sizeof(unsigned int));
-    else if (image->md[0].atype == _DATATYPE_UINT32)
-        memcpy(image->array.SI32, (int *)im, nbVal*sizeof(int));
-    else if (image->md[0].atype == _DATATYPE_UINT64)
-        memcpy(image->array.UI64, (unsigned long *)im, nbVal*sizeof(unsigned long));
-    else if (image->md[0].atype == _DATATYPE_INT64)
-        memcpy(image->array.SI64, (long *)im, nbVal*sizeof(long));
-    else if (image->md[0].atype == _DATATYPE_FLOAT)
-        memcpy(image->array.F, (float *)im, nbVal*sizeof(float));
-    else if (image->md[0].atype == _DATATYPE_DOUBLE)
-        memcpy(image->array.D, (double *)im, nbVal*sizeof(double));
-    else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
-        memcpy(image->array.CF, (complex_float *)im, nbVal*sizeof(complex_float));
-    else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
-        memcpy(image->array.CD, (complex_double *)im, nbVal*sizeof(complex_double));
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+
+    uint32_t last_written = vol_md[0].fifo_last_written;
+    uint32_t writing_idx = (last_written + 1) % (image->md[0].fifo_size);
+
+    uint64_t fifo_writing_offset = image->md[0].nelement * (uint64_t)writing_idx;
+
+    vol_md[writing_idx].write = 1;
+
+    if (image->md[writing_idx].atype == _DATATYPE_UINT8)
+        memcpy(&image->array.UI8[fifo_writing_offset], (unsigned char *)im, nbVal*sizeof(unsigned char)); 
+    else if (image->md[writing_idx].atype == _DATATYPE_INT8)
+        memcpy(&image->array.SI8[fifo_writing_offset], (char *)im, nbVal*sizeof(char));       
+    else if (image->md[writing_idx].atype == _DATATYPE_UINT16)
+        memcpy(&image->array.UI16[fifo_writing_offset], (unsigned short *)im, nbVal*sizeof(unsigned short));
+    else if (image->md[writing_idx].atype == _DATATYPE_INT16)
+        memcpy(&image->array.SI16[fifo_writing_offset], (short *)im, nbVal*sizeof(short));
+    else if (image->md[writing_idx].atype == _DATATYPE_INT32)
+        memcpy(&image->array.UI32[fifo_writing_offset], (unsigned int *)im, nbVal*sizeof(unsigned int));
+    else if (image->md[writing_idx].atype == _DATATYPE_UINT32)
+        memcpy(&image->array.SI32[fifo_writing_offset], (int *)im, nbVal*sizeof(int));
+    else if (image->md[writing_idx].atype == _DATATYPE_UINT64)
+        memcpy(&image->array.UI64[fifo_writing_offset], (unsigned long *)im, nbVal*sizeof(unsigned long));
+    else if (image->md[writing_idx].atype == _DATATYPE_INT64)
+        memcpy(&image->array.SI64[fifo_writing_offset], (long *)im, nbVal*sizeof(long));
+    else if (image->md[writing_idx].atype == _DATATYPE_FLOAT)
+        memcpy(&image->array.F[fifo_writing_offset], (float *)im, nbVal*sizeof(float));
+    else if (image->md[writing_idx].atype == _DATATYPE_DOUBLE)
+        memcpy(&image->array.D[fifo_writing_offset], (double *)im, nbVal*sizeof(double));
+    else if (image->md[writing_idx].atype == _DATATYPE_COMPLEX_FLOAT)
+        memcpy(&image->array.CF[fifo_writing_offset], (complex_float *)im, nbVal*sizeof(complex_float));
+    else if (image->md[writing_idx].atype == _DATATYPE_COMPLEX_DOUBLE)
+        memcpy(&image->array.CD[fifo_writing_offset], (complex_double *)im, nbVal*sizeof(complex_double));
 
     daoShmImagePart2ShmFinalize(image);
 
@@ -913,34 +921,42 @@ int_fast8_t daoShmImage2Shm(void *im, uint32_t nbVal, IMAGE *image)
 int_fast8_t daoShmImage2ShmQuiet(void *im, uint32_t nbVal, IMAGE *image) 
 {
     daoTrace("\n");
-    image->md[0].write = 1;
+
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+
+    uint32_t last_written = vol_md[0].fifo_last_written;
+    uint32_t writing_idx = (last_written + 1) % (image->md[0].fifo_size);
+
+    uint64_t fifo_writing_offset = image->md[0].nelement * (uint64_t)writing_idx;
+
+    image->md[writing_idx].write = 1;
 
     if (image->md[0].atype == _DATATYPE_UINT8)
-        memcpy(image->array.UI8, (unsigned char *)im, nbVal*sizeof(unsigned char)); 
+        memcpy(&image->array.UI8[fifo_writing_offset], (unsigned char *)im, nbVal*sizeof(unsigned char)); 
     else if (image->md[0].atype == _DATATYPE_INT8)
-        memcpy(image->array.SI8, (char *)im, nbVal*sizeof(char));       
+        memcpy(&image->array.SI8[fifo_writing_offset], (char *)im, nbVal*sizeof(char));       
     else if (image->md[0].atype == _DATATYPE_UINT16)
-        memcpy(image->array.UI16, (unsigned short *)im, nbVal*sizeof(unsigned short));
+        memcpy(&image->array.UI16[fifo_writing_offset], (unsigned short *)im, nbVal*sizeof(unsigned short));
     else if (image->md[0].atype == _DATATYPE_INT16)
-        memcpy(image->array.SI16, (short *)im, nbVal*sizeof(short));
+        memcpy(&image->array.SI16[fifo_writing_offset], (short *)im, nbVal*sizeof(short));
     else if (image->md[0].atype == _DATATYPE_INT32)
-        memcpy(image->array.UI32, (unsigned int *)im, nbVal*sizeof(unsigned int));
+        memcpy(&image->array.UI32[fifo_writing_offset], (unsigned int *)im, nbVal*sizeof(unsigned int));
     else if (image->md[0].atype == _DATATYPE_UINT32)
-        memcpy(image->array.SI32, (int *)im, nbVal*sizeof(int));
+        memcpy(&image->array.SI32[fifo_writing_offset], (int *)im, nbVal*sizeof(int));
     else if (image->md[0].atype == _DATATYPE_UINT64)
-        memcpy(image->array.UI64, (unsigned long *)im, nbVal*sizeof(unsigned long));
+        memcpy(&image->array.UI64[fifo_writing_offset], (unsigned long *)im, nbVal*sizeof(unsigned long));
     else if (image->md[0].atype == _DATATYPE_INT64)
-        memcpy(image->array.SI64, (long *)im, nbVal*sizeof(long));
+        memcpy(&image->array.SI64[fifo_writing_offset], (long *)im, nbVal*sizeof(long));
     else if (image->md[0].atype == _DATATYPE_FLOAT)
-        memcpy(image->array.F, (float *)im, nbVal*sizeof(float));
+        memcpy(&image->array.F[fifo_writing_offset], (float *)im, nbVal*sizeof(float));
     else if (image->md[0].atype == _DATATYPE_DOUBLE)
-        memcpy(image->array.D, (double *)im, nbVal*sizeof(double));
+        memcpy(&image->array.D[fifo_writing_offset], (double *)im, nbVal*sizeof(double));
     else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
-        memcpy(image->array.CF, (complex_float *)im, nbVal*sizeof(complex_float));
+        memcpy(&image->array.CF[fifo_writing_offset], (complex_float *)im, nbVal*sizeof(complex_float));
     else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
-        memcpy(image->array.CD, (complex_double *)im, nbVal*sizeof(complex_double));
+        memcpy(&image->array.CD[fifo_writing_offset], (complex_double *)im, nbVal*sizeof(complex_double));
 	
-    image->md[0].write = 0;
+    image->md[writing_idx].write = 0;
 
     return DAO_SUCCESS;
 }
@@ -953,40 +969,49 @@ int_fast8_t daoShmImagePart2Shm(char *im, uint32_t nbVal, IMAGE *image, uint32_t
                              uint16_t packetId, uint16_t packetTotal, uint64_t frameNumber) 
 {
     daoTrace("\n");
-    //int pp;
-    image->md[0].write = 1;
+
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+
+    uint32_t last_written = vol_md[0].fifo_last_written;
+    uint32_t writing_idx = (last_written + 1) % (image->md[0].fifo_size);
+
+    uint64_t fifo_writing_offset = image->md[0].nelement * (uint64_t)writing_idx;
+
+    uint64_t adjusted_position = (uint64_t)position + fifo_writing_offset;
+
+    image->md[writing_idx].write = 1;
 
     if (image->md[0].atype == _DATATYPE_UINT8)
-        memcpy(&image->array.UI8[position], (unsigned char *)im, nbVal*sizeof(unsigned char)); 
+        memcpy(&image->array.UI8[adjusted_position], (unsigned char *)im, nbVal*sizeof(unsigned char)); 
     else if (image->md[0].atype == _DATATYPE_INT8)
-        memcpy(&image->array.SI8[position], (char *)im, nbVal*sizeof(char));       
+        memcpy(&image->array.SI8[adjusted_position], (char *)im, nbVal*sizeof(char));       
     else if (image->md[0].atype == _DATATYPE_UINT16)
-        memcpy(&image->array.UI16[position], (unsigned short *)im, nbVal*sizeof(unsigned short));
+        memcpy(&image->array.UI16[adjusted_position], (unsigned short *)im, nbVal*sizeof(unsigned short));
     else if (image->md[0].atype == _DATATYPE_INT16)
-        memcpy(&image->array.SI16[position], (short *)im, nbVal*sizeof(short));
+        memcpy(&image->array.SI16[adjusted_position], (short *)im, nbVal*sizeof(short));
     else if (image->md[0].atype == _DATATYPE_INT32)
-        memcpy(&image->array.UI32[position], (unsigned int *)im, nbVal*sizeof(unsigned int));
+        memcpy(&image->array.UI32[adjusted_position], (unsigned int *)im, nbVal*sizeof(unsigned int));
     else if (image->md[0].atype == _DATATYPE_UINT32)
-        memcpy(&image->array.SI32[position], (int *)im, nbVal*sizeof(int));
+        memcpy(&image->array.SI32[adjusted_position], (int *)im, nbVal*sizeof(int));
     else if (image->md[0].atype == _DATATYPE_UINT64)
-        memcpy(&image->array.UI64[position], (unsigned long *)im, nbVal*sizeof(unsigned long));
+        memcpy(&image->array.UI64[adjusted_position], (unsigned long *)im, nbVal*sizeof(unsigned long));
     else if (image->md[0].atype == _DATATYPE_INT64)
-        memcpy(&image->array.SI64[position], (long *)im, nbVal*sizeof(long));
+        memcpy(&image->array.SI64[adjusted_position], (long *)im, nbVal*sizeof(long));
     else if (image->md[0].atype == _DATATYPE_FLOAT)
-        memcpy(&image->array.F[position], (float *)im, nbVal*sizeof(float));
+        memcpy(&image->array.F[adjusted_position], (float *)im, nbVal*sizeof(float));
     else if (image->md[0].atype == _DATATYPE_DOUBLE)
-        memcpy(&image->array.D[position], (double *)im, nbVal*sizeof(double));
+        memcpy(&image->array.D[adjusted_position], (double *)im, nbVal*sizeof(double));
     else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
-        memcpy(&image->array.CF[position], (complex_float *)im, nbVal*sizeof(complex_float));
+        memcpy(&image->array.CF[adjusted_position], (complex_float *)im, nbVal*sizeof(complex_float));
     else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
-        memcpy(&image->array.CD[position], (complex_double *)im, nbVal*sizeof(complex_double));
+        memcpy(&image->array.CD[adjusted_position], (complex_double *)im, nbVal*sizeof(complex_double));
 
-    image->md[0].lastPos = position;
-    image->md[0].lastNb = nbVal;
-    image->md[0].packetNb = packetId;
-    image->md[0].packetTotal = packetTotal;
-    image->md[0].lastNbArray[packetId] = frameNumber;
-    image->md[0].write = 0;
+    image->md[writing_idx].lastPos = position;
+    image->md[writing_idx].lastNb = nbVal;
+    image->md[writing_idx].packetNb = packetId;
+    image->md[writing_idx].packetTotal = packetTotal;
+    image->md[writing_idx].lastNbArray[packetId] = frameNumber;
+    image->md[writing_idx].write = 0;
 
     return DAO_SUCCESS;
 }
@@ -999,7 +1024,14 @@ int_fast8_t daoShmImagePart2ShmFinalize(IMAGE *image)
 {
     daoTrace("\n");
 
-    image->md[0].write = 0;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+
+    uint32_t last_written = vol_md[0].fifo_last_written;
+    uint32_t writing_idx = (last_written + 1) % (image->md[0].fifo_size);
+
+    image->md[writing_idx].write = 0;
+
+    image->md[0].fifo_last_written = writing_idx;
 
     daoShmTimestampShm(image);
     daoSemPostAll(image);
@@ -1436,6 +1468,7 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
 #endif
 	
         image->md = (IMAGE_METADATA*) map;
+        image->md[0].fifo_size = fifo_size;
 
         for (uint32_t fifo_idx = 0; fifo_idx < fifo_size; ++fifo_idx)
         {
@@ -1452,6 +1485,7 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
     else
     {
         image->md = (IMAGE_METADATA*) malloc(sizeof(IMAGE_METADATA) * fifo_size);
+        image->md[0].fifo_size = fifo_size;
 
         for (uint32_t fifo_idx = 0; fifo_idx < fifo_size; ++fifo_idx)
         {
@@ -1941,6 +1975,9 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
 		image->md[0].sem = 0; // no semaphores
     }
 
+    // set fifo last written position
+    image->md[0].fifo_size = fifo_size;
+    image->md[0].fifo_last_written = fifo_size - 1;
 
     // initialize keywords
     for(kw=0; kw<image->md[0].NBkw; kw++)

--- a/src/c/dao.c
+++ b/src/c/dao.c
@@ -2004,7 +2004,9 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
     daoTrace("\n");
     int pp;
     int k;
+    uint64_t fifo_reading_offset[DAO_MAX_COMBINE_CHANNELS];
 
+    // Get output image writing position
     volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
 
     uint32_t last_written = vol_md[0].fifo_last_written;
@@ -2013,6 +2015,25 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
     uint64_t fifo_writing_offset = image->md[0].nelement * (uint64_t)writing_idx;
 
     vol_md[writing_idx].write = 1;
+
+    // Fail if we are trying to combine too many channels
+    if (nbChannel > DAO_MAX_COMBINE_CHANNELS)
+    {
+        daoError("Attempted to combine more channels than is supported (%d > %d)\n",
+            nbChannel, DAO_MAX_COMBINE_CHANNELS);
+        return DAO_ERROR;
+    }
+
+    // Get input image reading positions
+    for (int k = 0; k < nbChannel; ++k)
+    {
+        volatile IMAGE_METADATA *reading_md = (volatile IMAGE_METADATA *)imageCube[k]->md;
+
+        uint32_t last_written = reading_md[0].fifo_last_written;
+        uint32_t writing_idx = (last_written + 1) % (imageCube[k]->md[0].fifo_size);
+
+        fifo_reading_offset[k] = imageCube[k]->md[0].nelement * (uint64_t)writing_idx;
+    }
     
     // check type and use proper array
     if (image->md[0].atype == _DATATYPE_UINT8)
@@ -2022,7 +2043,8 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
             image[0].array.UI8[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.UI8[fifo_writing_offset + pp] += imageCube[k][0].array.UI8[pp];
+                image[0].array.UI8[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.UI8[fifo_reading_offset[k] + pp];
             }
         }
     }
@@ -2033,7 +2055,8 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
             image[0].array.SI8[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.SI8[fifo_writing_offset + pp] += imageCube[k][0].array.SI8[pp];
+                image[0].array.SI8[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.SI8[fifo_reading_offset[k] + pp];
             }
         }
     }
@@ -2044,7 +2067,8 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
             image[0].array.UI16[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.UI16[fifo_writing_offset + pp] += imageCube[k][0].array.UI16[pp];
+                image[0].array.UI16[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.UI16[fifo_reading_offset[k] + pp];
             }
         }
     }
@@ -2055,7 +2079,8 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
             image[0].array.SI16[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.SI16[fifo_writing_offset + pp] += imageCube[k][0].array.SI16[pp];
+                image[0].array.SI16[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.SI16[fifo_reading_offset[k] + pp];
             }
         }
     }
@@ -2066,7 +2091,8 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
             image[0].array.UI32[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.UI32[fifo_writing_offset + pp] += imageCube[k][0].array.UI32[pp];
+                image[0].array.UI32[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.UI32[fifo_reading_offset[k] + pp];
             }
         }
     }
@@ -2077,7 +2103,8 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
             image[0].array.SI32[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.SI32[fifo_writing_offset + pp] += imageCube[k][0].array.SI32[pp];
+                image[0].array.SI32[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.SI32[fifo_reading_offset[k] + pp];
             }
         }
     }
@@ -2088,7 +2115,8 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
             image[0].array.UI64[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.UI64[fifo_writing_offset + pp] += imageCube[k][0].array.UI64[pp];
+                image[0].array.UI64[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.UI64[fifo_reading_offset[k] + pp];
             }
         }
     }
@@ -2099,7 +2127,8 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
             image[0].array.SI64[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.SI64[fifo_writing_offset + pp] += imageCube[k][0].array.SI64[pp];
+                image[0].array.SI64[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.SI64[fifo_reading_offset[k] + pp];
             }
         }
     }
@@ -2110,7 +2139,8 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
             image[0].array.F[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.F[fifo_writing_offset + pp] += imageCube[k][0].array.F[pp];
+                image[0].array.F[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.F[fifo_reading_offset[k] + pp];
             }
         }
     }
@@ -2121,7 +2151,8 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
             image[0].array.D[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.D[fifo_writing_offset + pp] += imageCube[k][0].array.D[pp];
+                image[0].array.D[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.D[fifo_reading_offset[k] + pp];
             }
         }
     }
@@ -2133,8 +2164,10 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
             image[0].array.CF[fifo_writing_offset + pp].im = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.CF[fifo_writing_offset + pp].re += imageCube[k][0].array.CF[pp].re;
-                image[0].array.CF[fifo_writing_offset + pp].im += imageCube[k][0].array.CF[pp].im;
+                image[0].array.CF[fifo_writing_offset + pp].re
+                    += imageCube[k][0].array.CF[fifo_reading_offset[k] + pp].re;
+                image[0].array.CF[fifo_writing_offset + pp].im
+                    += imageCube[k][0].array.CF[fifo_reading_offset[k] + pp].im;
             }
         }
     }
@@ -2146,8 +2179,10 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
             image[0].array.CD[fifo_writing_offset + pp].im = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.CD[fifo_writing_offset + pp].re += imageCube[k][0].array.CD[pp].re;
-                image[0].array.CD[fifo_writing_offset + pp].im += imageCube[k][0].array.CD[pp].im;
+                image[0].array.CD[fifo_writing_offset + pp].re
+                    += imageCube[k][0].array.CD[fifo_reading_offset[k] + pp].re;
+                image[0].array.CD[fifo_writing_offset + pp].im
+                    += imageCube[k][0].array.CD[fifo_reading_offset[k] + pp].im;
             }
         }
     }

--- a/src/c/dao.c
+++ b/src/c/dao.c
@@ -87,6 +87,41 @@ static int clock_gettime(int clk_id, struct timespec *t)
 #include "dao.h"
 static int current_log_level = DEFAULT_LOG_LEVEL;
 
+#define IMAGE_PTR_UPDATE(atype, array, base_array, idx, nelement) { \
+    if ((atype) == _DATATYPE_UINT8) \
+        (array).UI8 = &((base_array).UI8[(idx) * (nelement)]); \
+    else if (atype == _DATATYPE_INT8) \
+        (array).SI8 = &((base_array).SI8[(idx) * (nelement)]); \
+    else if (atype == _DATATYPE_UINT16) \
+        (array).UI16 = &((base_array).UI16[(idx) * (nelement)]); \
+    else if (atype == _DATATYPE_INT16) \
+        (array).SI16 = &((base_array).SI16[(idx) * (nelement)]); \
+    else if (atype == _DATATYPE_INT32) \
+        (array).UI32 = &((base_array).UI32[(idx) * (nelement)]); \
+    else if (atype == _DATATYPE_UINT32) \
+        (array).SI32 = &((base_array).SI32[(idx) * (nelement)]); \
+    else if (atype == _DATATYPE_UINT64) \
+        (array).UI64 = &((base_array).UI64[(idx) * (nelement)]); \
+    else if (atype == _DATATYPE_INT64) \
+        (array).SI64 = &((base_array).SI64[(idx) * (nelement)]); \
+    else if (atype == _DATATYPE_FLOAT) \
+        (array).F = &((base_array).F[(idx) * (nelement)]); \
+    else if (atype == _DATATYPE_DOUBLE) \
+        (array).D = &((base_array).D[(idx) * (nelement)]); \
+    else if (atype == _DATATYPE_COMPLEX_FLOAT) \
+        (array).CF = &((base_array).CF[(idx) * (nelement)]); \
+    else if (atype == _DATATYPE_COMPLEX_DOUBLE) \
+        (array).CD = &((base_array).CD[(idx) * (nelement)]); \
+}
+
+#define IMAGE_PTR_UPDATE_DIRECT(array, new_ptr) { \
+    (array).V = (void*)new_ptr; \
+}
+
+#define IMAGE_MD_PTR_UPDATE_IDX(image, new_md_idx) { \
+    image->md = &(image->base_md[new_md_idx]); \
+}
+
 /**
  * @brief Return a time stamp string with microsecond precision 
  * 
@@ -542,7 +577,7 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
 		image->memsize = (int64_t)fileSizeLow | ((int64_t)fileSizeHigh << 32);
 		image->shmfd = shmFd;
 		image->shmfm = shmFm;
-		image->md = map;
+		image->base_md = map;
 
 #else
 		
@@ -563,29 +598,29 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
 
         image->memsize = file_stat.st_size;
         image->shmfd = shmFd;
-        image->md = map;
-        //        image->md[0].sem = 0;
+        image->base_md = map;
+        //        image->base_md[0].sem = 0;
 
 #endif
-        atype = image->md[0].atype;
-        image->md[0].shared = 1;
+        atype = image->base_md[0].atype;
+        image->base_md[0].shared = 1;
 
-        daoDebug("image size = %ld %ld\n", (long) image->md[0].size[0], (long) image->md[0].size[1]);
+        daoDebug("image size = %ld %ld\n", (long) image->base_md[0].size[0], (long) image->base_md[0].size[1]);
         fflush(stdout);
         // some verification
-//        if(image->md[0].size[0]*image->md[0].size[1]>10000000000)
+//        if(image->base_md[0].size[0]*image->base_md[0].size[1]>10000000000)
 //        {
 //            daoDebug("IMAGE \"%s\" SEEMS BIG... ABORTING\n", name);
 //            rval = DAO_ERROR;
 //            exit(0);
 //        }
-        if(image->md[0].size[0]<1)
+        if(image->base_md[0].size[0]<1)
         {
             daoError("IMAGE \"%s\" AXIS SIZE < 1... ABORTING\n", name);
             rval = DAO_ERROR;
             exit(0);
         }
-        if(image->md[0].size[1]<1)
+        if(image->base_md[0].size[1]<1)
         {
             daoError("IMAGE \"%s\" AXIS SIZE < 1... ABORTING\n", name);
             rval = DAO_ERROR;
@@ -594,7 +629,7 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
 
         /* Get the size of the FIFO */
 
-        fifo_size = image->md[0].fifo_size;
+        fifo_size = image->base_md[0].fifo_size;
 
         mapv = (char*) map;
         mapv += fifo_size * sizeof(IMAGE_METADATA);
@@ -605,80 +640,80 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
         if(atype == _DATATYPE_UINT8)
         {
             daoDebug("atype = UINT8\n");
-            image->array.UI8 = (uint8_t*) mapv;
-            mapv += SIZEOF_DATATYPE_UINT8 * fifo_size * image->md[0].nelement;
+            image->base_array.UI8 = (uint8_t*) mapv;
+            mapv += SIZEOF_DATATYPE_UINT8 * fifo_size * image->base_md[0].nelement;
         }
         if(atype == _DATATYPE_INT8)
         {
             daoDebug("atype = INT8\n");
-            image->array.SI8 = (int8_t*) mapv;
-            mapv += SIZEOF_DATATYPE_INT8 * fifo_size * image->md[0].nelement;
+            image->base_array.SI8 = (int8_t*) mapv;
+            mapv += SIZEOF_DATATYPE_INT8 * fifo_size * image->base_md[0].nelement;
         }
         if(atype == _DATATYPE_UINT16)
         {
             daoDebug("atype = UINT16\n");
-            image->array.UI16 = (uint16_t*) mapv;
-            mapv += SIZEOF_DATATYPE_UINT16 * fifo_size * image->md[0].nelement;
+            image->base_array.UI16 = (uint16_t*) mapv;
+            mapv += SIZEOF_DATATYPE_UINT16 * fifo_size * image->base_md[0].nelement;
         }
         if(atype == _DATATYPE_INT16)
         {
             daoDebug("atype = INT16\n");
-            image->array.SI16 = (int16_t*) mapv;
-            mapv += SIZEOF_DATATYPE_INT16 * fifo_size * image->md[0].nelement;
+            image->base_array.SI16 = (int16_t*) mapv;
+            mapv += SIZEOF_DATATYPE_INT16 * fifo_size * image->base_md[0].nelement;
         }
         if(atype == _DATATYPE_UINT32)
         {
             daoDebug("atype = UINT32\n");
-            image->array.UI32 = (uint32_t*) mapv;
-            mapv += SIZEOF_DATATYPE_UINT32 * fifo_size * image->md[0].nelement;
+            image->base_array.UI32 = (uint32_t*) mapv;
+            mapv += SIZEOF_DATATYPE_UINT32 * fifo_size * image->base_md[0].nelement;
         }
         if(atype == _DATATYPE_INT32)
         {
             daoDebug("atype = INT32\n");
-            image->array.SI32 = (int32_t*) mapv;
-            mapv += SIZEOF_DATATYPE_INT32 * fifo_size * image->md[0].nelement;
+            image->base_array.SI32 = (int32_t*) mapv;
+            mapv += SIZEOF_DATATYPE_INT32 * fifo_size * image->base_md[0].nelement;
         }
         if(atype == _DATATYPE_UINT64)
         {
             daoDebug("atype = UINT64\n");
-            image->array.UI64 = (uint64_t*) mapv;
-            mapv += SIZEOF_DATATYPE_UINT64 * fifo_size * image->md[0].nelement;
+            image->base_array.UI64 = (uint64_t*) mapv;
+            mapv += SIZEOF_DATATYPE_UINT64 * fifo_size * image->base_md[0].nelement;
         }
         if(atype == _DATATYPE_INT64)
         {
             daoDebug("atype = INT64\n");
-            image->array.SI64 = (int64_t*) mapv;
-            mapv += SIZEOF_DATATYPE_INT64 * fifo_size * image->md[0].nelement;
+            image->base_array.SI64 = (int64_t*) mapv;
+            mapv += SIZEOF_DATATYPE_INT64 * fifo_size * image->base_md[0].nelement;
         }
         if(atype == _DATATYPE_FLOAT)
         {
             daoDebug("atype = FLOAT\n");
-            image->array.F = (float*) mapv;
-            mapv += SIZEOF_DATATYPE_FLOAT * fifo_size * image->md[0].nelement;
+            image->base_array.F = (float*) mapv;
+            mapv += SIZEOF_DATATYPE_FLOAT * fifo_size * image->base_md[0].nelement;
         }
         if(atype == _DATATYPE_DOUBLE)
         {
             daoDebug("atype = DOUBLE\n");
-            image->array.D = (double*) mapv;
-            mapv += SIZEOF_DATATYPE_DOUBLE * fifo_size * image->md[0].nelement;
+            image->base_array.D = (double*) mapv;
+            mapv += SIZEOF_DATATYPE_DOUBLE * fifo_size * image->base_md[0].nelement;
         }
         if(atype == _DATATYPE_COMPLEX_FLOAT)
         {
             daoDebug("atype = COMPLEX_FLOAT\n");
-            image->array.CF = (complex_float*) mapv;
-            mapv += SIZEOF_DATATYPE_COMPLEX_FLOAT * fifo_size * image->md[0].nelement;
+            image->base_array.CF = (complex_float*) mapv;
+            mapv += SIZEOF_DATATYPE_COMPLEX_FLOAT * fifo_size * image->base_md[0].nelement;
         }
         if(atype == _DATATYPE_COMPLEX_DOUBLE)
         {
             daoDebug("atype = COMPLEX_DOUBLE\n");
-            image->array.CD = (complex_double*) mapv;
-            mapv += SIZEOF_DATATYPE_COMPLEX_DOUBLE * fifo_size * image->md[0].nelement;
+            image->base_array.CD = (complex_double*) mapv;
+            mapv += SIZEOF_DATATYPE_COMPLEX_DOUBLE * fifo_size * image->base_md[0].nelement;
         }
-        daoDebug("%ld keywords\n", (long) image->md[0].NBkw);
+        daoDebug("%ld keywords\n", (long) image->base_md[0].NBkw);
         fflush(stdout);
 
         image->kw = (IMAGE_KEYWORD*) (mapv);
-        for(kw=0; kw<image->md[0].NBkw; kw++)
+        for(kw=0; kw<image->base_md[0].NBkw; kw++)
         {
             if(image->kw[kw].type == 'L')
                 #if defined(_WIN32) || defined(__APPLE__)
@@ -692,7 +727,7 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
                 daoDebug("%d  %s %s %s\n", kw, image->kw[kw].name, image->kw[kw].value.valstr, image->kw[kw].comment);
         }
 
-        mapv += sizeof(IMAGE_KEYWORD)*image->md[0].NBkw;
+        mapv += sizeof(IMAGE_KEYWORD)*image->base_md[0].NBkw;
         strcpy(image->name, name);
         // to get rid off warning
         char * nameCopy = (char *)malloc((strlen(name)+1)*sizeof(char));
@@ -766,9 +801,9 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
                 snb++;
             }
 		}
-        daoDebug("%ld semaphores detected  (image->md[0].sem = %d)\n", snb, (int) image->md[0].sem);
-        //        image->md[0].sem = snb;
-        image->semptr = (HANDLE*) malloc(sizeof(HANDLE) * image->md[0].sem);
+        daoDebug("%ld semaphores detected  (image->base_md[0].sem = %d)\n", snb, (int) image->base_md[0].sem);
+        //        image->base_md[0].sem = snb;
+        image->semptr = (HANDLE*) malloc(sizeof(HANDLE) * image->base_md[0].sem);
         for(s=0; s<snb; s++)
         {
             sprintf(shmSemName, "Local\\DAO_%s_sem%02ld", localName, s);
@@ -808,9 +843,9 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
                 snb++;
             }
         }
-        daoDebug("%ld semaphores detected  (image->md[0].sem = %d)\n", snb, (int) image->md[0].sem);
-        //        image->md[0].sem = snb;
-        image->semptr = (sem_t**) malloc(sizeof(sem_t*) * image->md[0].sem);
+        daoDebug("%ld semaphores detected  (image->base_md[0].sem = %d)\n", snb, (int) image->base_md[0].sem);
+        //        image->base_md[0].sem = snb;
+        image->semptr = (sem_t**) malloc(sizeof(sem_t*) * image->base_md[0].sem);
         for(s=0; s<snb; s++)
         {
             sprintf(shmSemName, "%s_sem%02ld", localName, s);
@@ -830,9 +865,15 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
 
         // Set up FIFO tail
 
-        uint32_t tmp32;
-        uint64_t tmp64;
-        daoShmResetTail(image, &tmp32, &tmp64);
+        uint32_t tail_idx;
+        uint64_t tail_cnt0;
+        daoShmResetTail(image, &tail_idx, &tail_cnt0);
+
+        // Set up array pointer for writing the one after our current position - this step is crucial for SHM writers, and
+        // has no effect on SHM reading, as long as the application always calls wait before the update
+
+        tail_idx = ((tail_idx + 1) >= image->base_md[0].fifo_size) ? 0 : tail_idx + 1;
+        IMAGE_MD_PTR_UPDATE_IDX(image, tail_idx);
     }
     return(rval);
 }
@@ -882,39 +923,39 @@ int_fast8_t daoShmImage2Shm(void *im, uint32_t nbVal, IMAGE *image)
 {
     daoTrace("\n");
 
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
 
     uint32_t last_written = vol_md[0].fifo_last_written;
-    uint32_t writing_idx = (last_written + 1) % (image->md[0].fifo_size);
+    uint32_t writing_idx = (last_written + 1) % (image->base_md[0].fifo_size);
 
-    uint64_t fifo_writing_offset = image->md[0].nelement * (uint64_t)writing_idx;
+    uint64_t fifo_writing_offset = image->base_md[0].nelement * (uint64_t)writing_idx;
 
     vol_md[writing_idx].write = 1;
 
-    if (image->md[writing_idx].atype == _DATATYPE_UINT8)
-        memcpy(&image->array.UI8[fifo_writing_offset], (unsigned char *)im, nbVal*sizeof(unsigned char)); 
-    else if (image->md[writing_idx].atype == _DATATYPE_INT8)
-        memcpy(&image->array.SI8[fifo_writing_offset], (char *)im, nbVal*sizeof(char));       
-    else if (image->md[writing_idx].atype == _DATATYPE_UINT16)
-        memcpy(&image->array.UI16[fifo_writing_offset], (unsigned short *)im, nbVal*sizeof(unsigned short));
-    else if (image->md[writing_idx].atype == _DATATYPE_INT16)
-        memcpy(&image->array.SI16[fifo_writing_offset], (short *)im, nbVal*sizeof(short));
-    else if (image->md[writing_idx].atype == _DATATYPE_INT32)
-        memcpy(&image->array.UI32[fifo_writing_offset], (unsigned int *)im, nbVal*sizeof(unsigned int));
-    else if (image->md[writing_idx].atype == _DATATYPE_UINT32)
-        memcpy(&image->array.SI32[fifo_writing_offset], (int *)im, nbVal*sizeof(int));
-    else if (image->md[writing_idx].atype == _DATATYPE_UINT64)
-        memcpy(&image->array.UI64[fifo_writing_offset], (unsigned long *)im, nbVal*sizeof(unsigned long));
-    else if (image->md[writing_idx].atype == _DATATYPE_INT64)
-        memcpy(&image->array.SI64[fifo_writing_offset], (long *)im, nbVal*sizeof(long));
-    else if (image->md[writing_idx].atype == _DATATYPE_FLOAT)
-        memcpy(&image->array.F[fifo_writing_offset], (float *)im, nbVal*sizeof(float));
-    else if (image->md[writing_idx].atype == _DATATYPE_DOUBLE)
-        memcpy(&image->array.D[fifo_writing_offset], (double *)im, nbVal*sizeof(double));
-    else if (image->md[writing_idx].atype == _DATATYPE_COMPLEX_FLOAT)
-        memcpy(&image->array.CF[fifo_writing_offset], (complex_float *)im, nbVal*sizeof(complex_float));
-    else if (image->md[writing_idx].atype == _DATATYPE_COMPLEX_DOUBLE)
-        memcpy(&image->array.CD[fifo_writing_offset], (complex_double *)im, nbVal*sizeof(complex_double));
+    if (image->base_md[writing_idx].atype == _DATATYPE_UINT8)
+        memcpy(&image->base_array.UI8[fifo_writing_offset], (unsigned char *)im, nbVal*sizeof(unsigned char)); 
+    else if (image->base_md[writing_idx].atype == _DATATYPE_INT8)
+        memcpy(&image->base_array.SI8[fifo_writing_offset], (char *)im, nbVal*sizeof(char));       
+    else if (image->base_md[writing_idx].atype == _DATATYPE_UINT16)
+        memcpy(&image->base_array.UI16[fifo_writing_offset], (unsigned short *)im, nbVal*sizeof(unsigned short));
+    else if (image->base_md[writing_idx].atype == _DATATYPE_INT16)
+        memcpy(&image->base_array.SI16[fifo_writing_offset], (short *)im, nbVal*sizeof(short));
+    else if (image->base_md[writing_idx].atype == _DATATYPE_INT32)
+        memcpy(&image->base_array.UI32[fifo_writing_offset], (unsigned int *)im, nbVal*sizeof(unsigned int));
+    else if (image->base_md[writing_idx].atype == _DATATYPE_UINT32)
+        memcpy(&image->base_array.SI32[fifo_writing_offset], (int *)im, nbVal*sizeof(int));
+    else if (image->base_md[writing_idx].atype == _DATATYPE_UINT64)
+        memcpy(&image->base_array.UI64[fifo_writing_offset], (unsigned long *)im, nbVal*sizeof(unsigned long));
+    else if (image->base_md[writing_idx].atype == _DATATYPE_INT64)
+        memcpy(&image->base_array.SI64[fifo_writing_offset], (long *)im, nbVal*sizeof(long));
+    else if (image->base_md[writing_idx].atype == _DATATYPE_FLOAT)
+        memcpy(&image->base_array.F[fifo_writing_offset], (float *)im, nbVal*sizeof(float));
+    else if (image->base_md[writing_idx].atype == _DATATYPE_DOUBLE)
+        memcpy(&image->base_array.D[fifo_writing_offset], (double *)im, nbVal*sizeof(double));
+    else if (image->base_md[writing_idx].atype == _DATATYPE_COMPLEX_FLOAT)
+        memcpy(&image->base_array.CF[fifo_writing_offset], (complex_float *)im, nbVal*sizeof(complex_float));
+    else if (image->base_md[writing_idx].atype == _DATATYPE_COMPLEX_DOUBLE)
+        memcpy(&image->base_array.CD[fifo_writing_offset], (complex_double *)im, nbVal*sizeof(complex_double));
 
     daoShmImagePart2ShmFinalize(image);
 
@@ -928,41 +969,41 @@ int_fast8_t daoShmImage2ShmQuiet(void *im, uint32_t nbVal, IMAGE *image)
 {
     daoTrace("\n");
 
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
 
     uint32_t last_written = vol_md[0].fifo_last_written;
-    uint32_t writing_idx = (last_written + 1) % (image->md[0].fifo_size);
+    uint32_t writing_idx = (last_written + 1) % (image->base_md[0].fifo_size);
 
-    uint64_t fifo_writing_offset = image->md[0].nelement * (uint64_t)writing_idx;
+    uint64_t fifo_writing_offset = image->base_md[0].nelement * (uint64_t)writing_idx;
 
-    image->md[writing_idx].write = 1;
+    image->base_md[writing_idx].write = 1;
 
-    if (image->md[0].atype == _DATATYPE_UINT8)
-        memcpy(&image->array.UI8[fifo_writing_offset], (unsigned char *)im, nbVal*sizeof(unsigned char)); 
-    else if (image->md[0].atype == _DATATYPE_INT8)
-        memcpy(&image->array.SI8[fifo_writing_offset], (char *)im, nbVal*sizeof(char));       
-    else if (image->md[0].atype == _DATATYPE_UINT16)
-        memcpy(&image->array.UI16[fifo_writing_offset], (unsigned short *)im, nbVal*sizeof(unsigned short));
-    else if (image->md[0].atype == _DATATYPE_INT16)
-        memcpy(&image->array.SI16[fifo_writing_offset], (short *)im, nbVal*sizeof(short));
-    else if (image->md[0].atype == _DATATYPE_INT32)
-        memcpy(&image->array.UI32[fifo_writing_offset], (unsigned int *)im, nbVal*sizeof(unsigned int));
-    else if (image->md[0].atype == _DATATYPE_UINT32)
-        memcpy(&image->array.SI32[fifo_writing_offset], (int *)im, nbVal*sizeof(int));
-    else if (image->md[0].atype == _DATATYPE_UINT64)
-        memcpy(&image->array.UI64[fifo_writing_offset], (unsigned long *)im, nbVal*sizeof(unsigned long));
-    else if (image->md[0].atype == _DATATYPE_INT64)
-        memcpy(&image->array.SI64[fifo_writing_offset], (long *)im, nbVal*sizeof(long));
-    else if (image->md[0].atype == _DATATYPE_FLOAT)
-        memcpy(&image->array.F[fifo_writing_offset], (float *)im, nbVal*sizeof(float));
-    else if (image->md[0].atype == _DATATYPE_DOUBLE)
-        memcpy(&image->array.D[fifo_writing_offset], (double *)im, nbVal*sizeof(double));
-    else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
-        memcpy(&image->array.CF[fifo_writing_offset], (complex_float *)im, nbVal*sizeof(complex_float));
-    else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
-        memcpy(&image->array.CD[fifo_writing_offset], (complex_double *)im, nbVal*sizeof(complex_double));
+    if (image->base_md[0].atype == _DATATYPE_UINT8)
+        memcpy(&image->base_array.UI8[fifo_writing_offset], (unsigned char *)im, nbVal*sizeof(unsigned char)); 
+    else if (image->base_md[0].atype == _DATATYPE_INT8)
+        memcpy(&image->base_array.SI8[fifo_writing_offset], (char *)im, nbVal*sizeof(char));       
+    else if (image->base_md[0].atype == _DATATYPE_UINT16)
+        memcpy(&image->base_array.UI16[fifo_writing_offset], (unsigned short *)im, nbVal*sizeof(unsigned short));
+    else if (image->base_md[0].atype == _DATATYPE_INT16)
+        memcpy(&image->base_array.SI16[fifo_writing_offset], (short *)im, nbVal*sizeof(short));
+    else if (image->base_md[0].atype == _DATATYPE_INT32)
+        memcpy(&image->base_array.UI32[fifo_writing_offset], (unsigned int *)im, nbVal*sizeof(unsigned int));
+    else if (image->base_md[0].atype == _DATATYPE_UINT32)
+        memcpy(&image->base_array.SI32[fifo_writing_offset], (int *)im, nbVal*sizeof(int));
+    else if (image->base_md[0].atype == _DATATYPE_UINT64)
+        memcpy(&image->base_array.UI64[fifo_writing_offset], (unsigned long *)im, nbVal*sizeof(unsigned long));
+    else if (image->base_md[0].atype == _DATATYPE_INT64)
+        memcpy(&image->base_array.SI64[fifo_writing_offset], (long *)im, nbVal*sizeof(long));
+    else if (image->base_md[0].atype == _DATATYPE_FLOAT)
+        memcpy(&image->base_array.F[fifo_writing_offset], (float *)im, nbVal*sizeof(float));
+    else if (image->base_md[0].atype == _DATATYPE_DOUBLE)
+        memcpy(&image->base_array.D[fifo_writing_offset], (double *)im, nbVal*sizeof(double));
+    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_FLOAT)
+        memcpy(&image->base_array.CF[fifo_writing_offset], (complex_float *)im, nbVal*sizeof(complex_float));
+    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
+        memcpy(&image->base_array.CD[fifo_writing_offset], (complex_double *)im, nbVal*sizeof(complex_double));
 	
-    image->md[writing_idx].write = 0;
+    image->base_md[writing_idx].write = 0;
 
     return DAO_SUCCESS;
 }
@@ -976,48 +1017,48 @@ int_fast8_t daoShmImagePart2Shm(char *im, uint32_t nbVal, IMAGE *image, uint32_t
 {
     daoTrace("\n");
 
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
 
     uint32_t last_written = vol_md[0].fifo_last_written;
-    uint32_t writing_idx = (last_written + 1) % (image->md[0].fifo_size);
+    uint32_t writing_idx = (last_written + 1) % (image->base_md[0].fifo_size);
 
-    uint64_t fifo_writing_offset = image->md[0].nelement * (uint64_t)writing_idx;
+    uint64_t fifo_writing_offset = image->base_md[0].nelement * (uint64_t)writing_idx;
 
     uint64_t adjusted_position = (uint64_t)position + fifo_writing_offset;
 
-    image->md[writing_idx].write = 1;
+    image->base_md[writing_idx].write = 1;
 
-    if (image->md[0].atype == _DATATYPE_UINT8)
-        memcpy(&image->array.UI8[adjusted_position], (unsigned char *)im, nbVal*sizeof(unsigned char)); 
-    else if (image->md[0].atype == _DATATYPE_INT8)
-        memcpy(&image->array.SI8[adjusted_position], (char *)im, nbVal*sizeof(char));       
-    else if (image->md[0].atype == _DATATYPE_UINT16)
-        memcpy(&image->array.UI16[adjusted_position], (unsigned short *)im, nbVal*sizeof(unsigned short));
-    else if (image->md[0].atype == _DATATYPE_INT16)
-        memcpy(&image->array.SI16[adjusted_position], (short *)im, nbVal*sizeof(short));
-    else if (image->md[0].atype == _DATATYPE_INT32)
-        memcpy(&image->array.UI32[adjusted_position], (unsigned int *)im, nbVal*sizeof(unsigned int));
-    else if (image->md[0].atype == _DATATYPE_UINT32)
-        memcpy(&image->array.SI32[adjusted_position], (int *)im, nbVal*sizeof(int));
-    else if (image->md[0].atype == _DATATYPE_UINT64)
-        memcpy(&image->array.UI64[adjusted_position], (unsigned long *)im, nbVal*sizeof(unsigned long));
-    else if (image->md[0].atype == _DATATYPE_INT64)
-        memcpy(&image->array.SI64[adjusted_position], (long *)im, nbVal*sizeof(long));
-    else if (image->md[0].atype == _DATATYPE_FLOAT)
-        memcpy(&image->array.F[adjusted_position], (float *)im, nbVal*sizeof(float));
-    else if (image->md[0].atype == _DATATYPE_DOUBLE)
-        memcpy(&image->array.D[adjusted_position], (double *)im, nbVal*sizeof(double));
-    else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
-        memcpy(&image->array.CF[adjusted_position], (complex_float *)im, nbVal*sizeof(complex_float));
-    else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
-        memcpy(&image->array.CD[adjusted_position], (complex_double *)im, nbVal*sizeof(complex_double));
+    if (image->base_md[0].atype == _DATATYPE_UINT8)
+        memcpy(&image->base_array.UI8[adjusted_position], (unsigned char *)im, nbVal*sizeof(unsigned char)); 
+    else if (image->base_md[0].atype == _DATATYPE_INT8)
+        memcpy(&image->base_array.SI8[adjusted_position], (char *)im, nbVal*sizeof(char));       
+    else if (image->base_md[0].atype == _DATATYPE_UINT16)
+        memcpy(&image->base_array.UI16[adjusted_position], (unsigned short *)im, nbVal*sizeof(unsigned short));
+    else if (image->base_md[0].atype == _DATATYPE_INT16)
+        memcpy(&image->base_array.SI16[adjusted_position], (short *)im, nbVal*sizeof(short));
+    else if (image->base_md[0].atype == _DATATYPE_INT32)
+        memcpy(&image->base_array.UI32[adjusted_position], (unsigned int *)im, nbVal*sizeof(unsigned int));
+    else if (image->base_md[0].atype == _DATATYPE_UINT32)
+        memcpy(&image->base_array.SI32[adjusted_position], (int *)im, nbVal*sizeof(int));
+    else if (image->base_md[0].atype == _DATATYPE_UINT64)
+        memcpy(&image->base_array.UI64[adjusted_position], (unsigned long *)im, nbVal*sizeof(unsigned long));
+    else if (image->base_md[0].atype == _DATATYPE_INT64)
+        memcpy(&image->base_array.SI64[adjusted_position], (long *)im, nbVal*sizeof(long));
+    else if (image->base_md[0].atype == _DATATYPE_FLOAT)
+        memcpy(&image->base_array.F[adjusted_position], (float *)im, nbVal*sizeof(float));
+    else if (image->base_md[0].atype == _DATATYPE_DOUBLE)
+        memcpy(&image->base_array.D[adjusted_position], (double *)im, nbVal*sizeof(double));
+    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_FLOAT)
+        memcpy(&image->base_array.CF[adjusted_position], (complex_float *)im, nbVal*sizeof(complex_float));
+    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
+        memcpy(&image->base_array.CD[adjusted_position], (complex_double *)im, nbVal*sizeof(complex_double));
 
-    image->md[writing_idx].lastPos = position;
-    image->md[writing_idx].lastNb = nbVal;
-    image->md[writing_idx].packetNb = packetId;
-    image->md[writing_idx].packetTotal = packetTotal;
-    image->md[writing_idx].lastNbArray[packetId] = frameNumber;
-    image->md[writing_idx].write = 0;
+    image->base_md[writing_idx].lastPos = position;
+    image->base_md[writing_idx].lastNb = nbVal;
+    image->base_md[writing_idx].packetNb = packetId;
+    image->base_md[writing_idx].packetTotal = packetTotal;
+    image->base_md[writing_idx].lastNbArray[packetId] = frameNumber;
+    image->base_md[writing_idx].write = 0;
 
     return DAO_SUCCESS;
 }
@@ -1030,14 +1071,18 @@ int_fast8_t daoShmImagePart2ShmFinalize(IMAGE *image)
 {
     daoTrace("\n");
 
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
 
     uint32_t last_written = vol_md[0].fifo_last_written;
-    uint32_t writing_idx = (last_written + 1) % (image->md[0].fifo_size);
+    uint32_t writing_idx = (last_written + 1) % (image->base_md[0].fifo_size);
 
-    image->md[writing_idx].write = 0;
+    // idx to update current image array pointer with (for FIFO compatibility)
+    uint32_t next_writing_idx = ((writing_idx + 1) < image->base_md[0].fifo_size) ?
+        writing_idx + 1 : 0;
 
-    image->md[0].fifo_last_written = writing_idx;
+    image->base_md[writing_idx].write = 0;
+
+    image->base_md[0].fifo_last_written = writing_idx;
 
     daoShmTimestampShm(image);
     daoSemPostAll(image);
@@ -1046,7 +1091,11 @@ int_fast8_t daoShmImagePart2ShmFinalize(IMAGE *image)
     {
         daoSemLogPost(image);
     }
-	 
+
+    IMAGE_PTR_UPDATE(image->base_md[0].atype, image->array, image->base_array,
+        next_writing_idx, image->base_md[0].nelement);
+    
+    IMAGE_MD_PTR_UPDATE_IDX(image, next_writing_idx);
 
     return DAO_SUCCESS;
 }
@@ -1076,14 +1125,14 @@ int_fast8_t daoImageCreateSem(IMAGE *image, long NBsem)
 #endif
 
 	//printf("%p\n", image);
-	//printf("%p\n", &(image->md[0]));
-	//printf("%p\n", &(image->md[0].name));
-	//printf("%s\n", image->md[0].name);
+	//printf("%p\n", &(image->base_md[0]));
+	//printf("%p\n", &(image->base_md[0].name));
+	//printf("%s\n", image->base_md[0].name);
 	//printf("%p\n", &strlen);
 
     // to get rid off warning
-    char * nameCopy = (char *)malloc((strlen(image->md[0].name)+1)*sizeof(char));
-    strcpy(nameCopy, image->md[0].name);
+    char * nameCopy = (char *)malloc((strlen(image->base_md[0].name)+1)*sizeof(char));
+    strcpy(nameCopy, image->base_md[0].name);
 	
     char *token = strtok(nameCopy, PATH_SEPARATOR);
 
@@ -1127,30 +1176,30 @@ int_fast8_t daoImageCreateSem(IMAGE *image, long NBsem)
 		return DAO_ERROR;
 	}
 	
-    if(image->md[0].sem != NBsem)
+    if(image->base_md[0].sem != NBsem)
     {
         // Close existing semaphores ...
         daoInfo("Closing semaphore\n");
-        for(s=0; s < image->md[0].sem; s++)
+        for(s=0; s < image->base_md[0].sem; s++)
         {
             CloseHandle(image->semptr[s]);
         }
-        image->md[0].sem = 0;
+        image->base_md[0].sem = 0;
 
         daoInfo("Done\n");
         //free(image->semptr);
         image->semptr = NULL;
     }
 #else
-    if(image->md[0].sem != NBsem)
+    if(image->base_md[0].sem != NBsem)
     {
         // Close existing semaphores ...
         daoInfo("Closing semaphore\n");
-        for(s=0; s < image->md[0].sem; s++)
+        for(s=0; s < image->base_md[0].sem; s++)
         {
             sem_close(image->semptr[s]);
         }
-        image->md[0].sem = 0;
+        image->base_md[0].sem = 0;
 
         daoInfo("Remove associated files\n");
 		// ... and remove associated files
@@ -1167,18 +1216,18 @@ int_fast8_t daoImageCreateSem(IMAGE *image, long NBsem)
 #endif
 
 
-    if(image->md[0].sem == 0)
+    if(image->base_md[0].sem == 0)
     {
         if(image->semptr!=NULL)
             free(image->semptr);
 
-        image->md[0].sem = (uint16_t)NBsem;
-        daoInfo("malloc semptr %d entries\n", image->md[0].sem);
+        image->base_md[0].sem = (uint16_t)NBsem;
+        daoInfo("malloc semptr %d entries\n", image->base_md[0].sem);
 
 #ifdef _WIN32
-        image->semptr = (HANDLE*) malloc(sizeof(HANDLE*)*image->md[0].sem);
+        image->semptr = (HANDLE*) malloc(sizeof(HANDLE*)*image->base_md[0].sem);
 #else
-        image->semptr = (sem_t**) malloc(sizeof(sem_t**)*image->md[0].sem);
+        image->semptr = (sem_t**) malloc(sizeof(sem_t**)*image->base_md[0].sem);
 #endif
         
         for(s=0; s<NBsem; s++)
@@ -1473,13 +1522,13 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         }
 #endif
 	
-        image->md = (IMAGE_METADATA*) map;
-        image->md[0].fifo_size = fifo_size;
+        image->base_md = (IMAGE_METADATA*) map;
+        image->base_md[0].fifo_size = fifo_size;
 
         for (uint32_t fifo_idx = 0; fifo_idx < fifo_size; ++fifo_idx)
         {
-            image->md[fifo_idx].shared = 1;
-            image->md[fifo_idx].sem = 0;
+            image->base_md[fifo_idx].shared = 1;
+            image->base_md[fifo_idx].sem = 0;
         }
 
         free(nameCopy);
@@ -1490,12 +1539,12 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
     }
     else
     {
-        image->md = (IMAGE_METADATA*) malloc(sizeof(IMAGE_METADATA) * fifo_size);
-        image->md[0].fifo_size = fifo_size;
+        image->base_md = (IMAGE_METADATA*) malloc(sizeof(IMAGE_METADATA) * fifo_size);
+        image->base_md[0].fifo_size = fifo_size;
 
         for (uint32_t fifo_idx = 0; fifo_idx < fifo_size; ++fifo_idx)
         {
-            image->md[fifo_idx].shared = 0;
+            image->base_md[fifo_idx].shared = 0;
         }
 
         if(NBkw>0)
@@ -1511,16 +1560,16 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
     strcpy(image->name, name); // local name
     for (uint32_t fifo_idx = 0; fifo_idx < fifo_size; ++fifo_idx)
     {
-        image->md[fifo_idx].atype = atype;
-        image->md[fifo_idx].naxis = (uint8_t)naxis;
+        image->base_md[fifo_idx].atype = atype;
+        image->base_md[fifo_idx].naxis = (uint8_t)naxis;
 
-        strcpy(image->md[fifo_idx].name, name);
+        strcpy(image->base_md[fifo_idx].name, name);
 
         for(i=0; i<naxis; i++)
         {
-            image->md[fifo_idx].size[i] = size[i];
+            image->base_md[fifo_idx].size[i] = size[i];
         }
-        image->md[fifo_idx].NBkw = NBkw;
+        image->base_md[fifo_idx].NBkw = NBkw;
     }
 
 
@@ -1530,18 +1579,18 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
 			mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
-            image->array.UI8 = (uint8_t*) (mapv);
-            memset(image->array.UI8, '\0', nelement*sizeof(uint8_t));
+            image->base_array.UI8 = (uint8_t*) (mapv);
+            memset(image->base_array.UI8, '\0', nelement*sizeof(uint8_t));
             mapv += sizeof(uint8_t)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
 		}
         else
         {
-            image->array.UI8 = (uint8_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint8_t));
+            image->base_array.UI8 = (uint8_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint8_t));
         }
 
 
-        if(image->array.UI8 == NULL)
+        if(image->base_array.UI8 == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1564,16 +1613,16 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
 			mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
-            image->array.SI8 = (int8_t*) (mapv);
-            memset(image->array.SI8, '\0', nelement*sizeof(int8_t));
+            image->base_array.SI8 = (int8_t*) (mapv);
+            memset(image->base_array.SI8, '\0', nelement*sizeof(int8_t));
             mapv += sizeof(int8_t)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
 		}
         else
-            image->array.SI8 = (int8_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int8_t));
+            image->base_array.SI8 = (int8_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int8_t));
 
 
-        if(image->array.SI8 == NULL)
+        if(image->base_array.SI8 == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1598,17 +1647,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
             mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
-            image->array.UI16 = (uint16_t*) (mapv);
-            memset(image->array.UI16, '\0', nelement*sizeof(uint16_t));
+            image->base_array.UI16 = (uint16_t*) (mapv);
+            memset(image->base_array.UI16, '\0', nelement*sizeof(uint16_t));
             mapv += sizeof(uint16_t)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->array.UI16 = (uint16_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint16_t));
+            image->base_array.UI16 = (uint16_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint16_t));
         }
 
-        if(image->array.UI16 == NULL)
+        if(image->base_array.UI16 == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1631,17 +1680,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
             mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
-            image->array.SI16 = (int16_t*) (mapv);
-            memset(image->array.SI16, '\0', nelement*sizeof(int16_t));
+            image->base_array.SI16 = (int16_t*) (mapv);
+            memset(image->base_array.SI16, '\0', nelement*sizeof(int16_t));
             mapv += sizeof(int16_t)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->array.SI16 = (int16_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int16_t));
+            image->base_array.SI16 = (int16_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int16_t));
         }
 
-        if(image->array.SI16 == NULL)
+        if(image->base_array.SI16 == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1667,17 +1716,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
 			mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
-            image->array.UI32 = (uint32_t*) (mapv);
-            memset(image->array.UI32, '\0', nelement*sizeof(uint32_t));
+            image->base_array.UI32 = (uint32_t*) (mapv);
+            memset(image->base_array.UI32, '\0', nelement*sizeof(uint32_t));
             mapv += sizeof(uint32_t)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->array.UI32 = (uint32_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint32_t));
+            image->base_array.UI32 = (uint32_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint32_t));
         }
 
-        if(image->array.UI32 == NULL)
+        if(image->base_array.UI32 == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1704,17 +1753,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
 			mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
-            image->array.SI32 = (int32_t*) (mapv);
-            memset(image->array.SI32, '\0', nelement*sizeof(int32_t));
+            image->base_array.SI32 = (int32_t*) (mapv);
+            memset(image->base_array.SI32, '\0', nelement*sizeof(int32_t));
             mapv += sizeof(int32_t)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->array.SI32 = (int32_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int32_t));
+            image->base_array.SI32 = (int32_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int32_t));
         }
 
-        if(image->array.SI32 == NULL)
+        if(image->base_array.SI32 == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1741,17 +1790,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
 			mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
-            image->array.UI64 = (uint64_t*) (mapv);
-            memset(image->array.UI64, '\0', nelement*sizeof(uint64_t));
+            image->base_array.UI64 = (uint64_t*) (mapv);
+            memset(image->base_array.UI64, '\0', nelement*sizeof(uint64_t));
             mapv += sizeof(uint64_t)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->array.UI64 = (uint64_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint64_t));
+            image->base_array.UI64 = (uint64_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint64_t));
         }
 
-        if(image->array.SI64 == NULL)
+        if(image->base_array.SI64 == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1776,17 +1825,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
 			mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
-            image->array.SI64 = (int64_t*) (mapv);
-            memset(image->array.SI64, '\0', nelement*sizeof(int64_t));
+            image->base_array.SI64 = (int64_t*) (mapv);
+            memset(image->base_array.SI64, '\0', nelement*sizeof(int64_t));
             mapv += sizeof(int64_t)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->array.SI64 = (int64_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int64_t));
+            image->base_array.SI64 = (int64_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int64_t));
         }
 
-        if(image->array.SI64 == NULL)
+        if(image->base_array.SI64 == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1812,17 +1861,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
             mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
-            image->array.F = (float*) (mapv);
-            memset(image->array.F, '\0', nelement*sizeof(float));
+            image->base_array.F = (float*) (mapv);
+            memset(image->base_array.F, '\0', nelement*sizeof(float));
             mapv += sizeof(float)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->array.F = (float*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(float));
+            image->base_array.F = (float*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(float));
         }
 
-        if(image->array.F == NULL)
+        if(image->base_array.F == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1847,17 +1896,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
 			mapv = (char*) map;
 			mapv += sizeof(IMAGE_METADATA) * fifo_size;
-			image->array.D = (double*) (mapv);
-            memset(image->array.D, '\0', nelement*sizeof(double));
+			image->base_array.D = (double*) (mapv);
+            memset(image->base_array.D, '\0', nelement*sizeof(double));
             mapv += sizeof(double)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->array.D = (double*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(double));
+            image->base_array.D = (double*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(double));
         }
   
-        if(image->array.D == NULL)
+        if(image->base_array.D == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1882,17 +1931,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
 			mapv = (char*) map;
 			mapv += sizeof(IMAGE_METADATA) * fifo_size;
-			image->array.CF = (complex_float*) (mapv);			
-            memset(image->array.CF, '\0', nelement*sizeof(complex_float));
+			image->base_array.CF = (complex_float*) (mapv);			
+            memset(image->base_array.CF, '\0', nelement*sizeof(complex_float));
             mapv += sizeof(complex_float)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->array.CF = (complex_float*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(complex_float));
+            image->base_array.CF = (complex_float*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(complex_float));
         }
 
-        if(image->array.CF == NULL)
+        if(image->base_array.CF == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1917,17 +1966,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
 			mapv = (char*) map;
 			mapv += sizeof(IMAGE_METADATA) * fifo_size;
-			image->array.CD = (complex_double*) (mapv);			
-            memset(image->array.CD, '\0', nelement*sizeof(complex_double));
+			image->base_array.CD = (complex_double*) (mapv);			
+            memset(image->base_array.CD, '\0', nelement*sizeof(complex_double));
             mapv += sizeof(complex_double)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->array.CD = (complex_double*) calloc ((size_t) nelement * (size_t) fifo_size,sizeof(complex_double));
+            image->base_array.CD = (complex_double*) calloc ((size_t) nelement * (size_t) fifo_size,sizeof(complex_double));
         }
 
-        if(image->array.CD == NULL)
+        if(image->base_array.CD == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1950,12 +1999,12 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
 
     for (uint32_t fifo_idx = 0; fifo_idx < fifo_size; ++fifo_idx)
     {
-        image->md[fifo_idx].last_access = 1.0*timenow.tv_sec + 0.000000001*timenow.tv_nsec;
-        image->md[fifo_idx].creation_time = image->md[0].last_access;
-        image->md[fifo_idx].write = 0;
-        image->md[fifo_idx].cnt0 = 0;
-        image->md[fifo_idx].cnt1 = 0;
-        image->md[fifo_idx].nelement = nelement;
+        image->base_md[fifo_idx].last_access = 1.0*timenow.tv_sec + 0.000000001*timenow.tv_nsec;
+        image->base_md[fifo_idx].creation_time = image->base_md[0].last_access;
+        image->base_md[fifo_idx].write = 0;
+        image->base_md[fifo_idx].cnt0 = 0;
+        image->base_md[fifo_idx].cnt1 = 0;
+        image->base_md[fifo_idx].nelement = nelement;
     }
 
     if(shared==1)
@@ -1965,34 +2014,40 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         daoInfo("Semaphores created\n");
 
 #ifdef __APPLE__
-        for (int i = 0; i < image->md[0].sem; i++)
+        for (int i = 0; i < image->base_md[0].sem; i++)
         {
             while (sem_trywait(image->semptr[i]) == 0) 
             {
                 // Draining kernel-level semaphore
             }
-            atomic_store(&image->md[0].semCounter[i], 0);
+            atomic_store(&image->base_md[0].semCounter[i], 0);
         }
-        atomic_store(&image->md[0].semLogCounter, 0);
+        atomic_store(&image->base_md[0].semLogCounter, 0);
 #endif
     }
     else
     {
-		image->md[0].sem = 0; // no semaphores
+		image->base_md[0].sem = 0; // no semaphores
     }
 
     // set fifo last written position
-    image->md[0].fifo_size = fifo_size;
-    image->md[0].fifo_last_written = fifo_size - 1;
+    image->base_md[0].fifo_size = fifo_size;
+    image->base_md[0].fifo_last_written = fifo_size - 1;
 
     // set up FIFO tail
 
-    uint32_t tmp32;
-    uint64_t tmp64;
-    daoShmResetTail(image, &tmp32, &tmp64);
+    uint32_t tail_idx;
+    uint64_t tail_cnt0;
+    daoShmResetTail(image, &tail_idx, &tail_cnt0);
+
+    // Set up array pointer for writing the one after our current position - this step is crucial for SHM writers, and
+    // has no effect on SHM reading, as long as the application always calls wait before the update
+
+    tail_idx = ((tail_idx + 1) >= image->base_md[0].fifo_size) ? 0 : tail_idx + 1;
+    IMAGE_MD_PTR_UPDATE_IDX(image, tail_idx);
 
     // initialize keywords
-    for(kw=0; kw<image->md[0].NBkw; kw++)
+    for(kw=0; kw<image->base_md[0].NBkw; kw++)
     {
         image->kw[kw].type = 'N';
     }
@@ -2007,12 +2062,12 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
     uint64_t fifo_reading_offset[DAO_MAX_COMBINE_CHANNELS];
 
     // Get output image writing position
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
 
     uint32_t last_written = vol_md[0].fifo_last_written;
-    uint32_t writing_idx = (last_written + 1) % (image->md[0].fifo_size);
+    uint32_t writing_idx = (last_written + 1) % (image->base_md[0].fifo_size);
 
-    uint64_t fifo_writing_offset = image->md[0].nelement * (uint64_t)writing_idx;
+    uint64_t fifo_writing_offset = image->base_md[0].nelement * (uint64_t)writing_idx;
 
     vol_md[writing_idx].write = 1;
 
@@ -2036,153 +2091,153 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
     }
     
     // check type and use proper array
-    if (image->md[0].atype == _DATATYPE_UINT8)
+    if (image->base_md[0].atype == _DATATYPE_UINT8)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.UI8[fifo_writing_offset + pp] = 0;
+            image[0].base_array.UI8[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.UI8[fifo_writing_offset + pp]
-                    += imageCube[k][0].array.UI8[fifo_reading_offset[k] + pp];
+                image[0].base_array.UI8[fifo_writing_offset + pp]
+                    += imageCube[k][0].base_array.UI8[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->md[0].atype == _DATATYPE_INT8)
+    else if (image->base_md[0].atype == _DATATYPE_INT8)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.SI8[fifo_writing_offset + pp] = 0;
+            image[0].base_array.SI8[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.SI8[fifo_writing_offset + pp]
-                    += imageCube[k][0].array.SI8[fifo_reading_offset[k] + pp];
+                image[0].base_array.SI8[fifo_writing_offset + pp]
+                    += imageCube[k][0].base_array.SI8[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->md[0].atype == _DATATYPE_UINT16)
+    else if (image->base_md[0].atype == _DATATYPE_UINT16)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.UI16[fifo_writing_offset + pp] = 0;
+            image[0].base_array.UI16[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.UI16[fifo_writing_offset + pp]
-                    += imageCube[k][0].array.UI16[fifo_reading_offset[k] + pp];
+                image[0].base_array.UI16[fifo_writing_offset + pp]
+                    += imageCube[k][0].base_array.UI16[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->md[0].atype == _DATATYPE_INT16)
+    else if (image->base_md[0].atype == _DATATYPE_INT16)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.SI16[fifo_writing_offset + pp] = 0;
+            image[0].base_array.SI16[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.SI16[fifo_writing_offset + pp]
-                    += imageCube[k][0].array.SI16[fifo_reading_offset[k] + pp];
+                image[0].base_array.SI16[fifo_writing_offset + pp]
+                    += imageCube[k][0].base_array.SI16[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->md[0].atype == _DATATYPE_UINT32)
+    else if (image->base_md[0].atype == _DATATYPE_UINT32)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.UI32[fifo_writing_offset + pp] = 0;
+            image[0].base_array.UI32[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.UI32[fifo_writing_offset + pp]
-                    += imageCube[k][0].array.UI32[fifo_reading_offset[k] + pp];
+                image[0].base_array.UI32[fifo_writing_offset + pp]
+                    += imageCube[k][0].base_array.UI32[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->md[0].atype == _DATATYPE_INT32)
+    else if (image->base_md[0].atype == _DATATYPE_INT32)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.SI32[fifo_writing_offset + pp] = 0;
+            image[0].base_array.SI32[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.SI32[fifo_writing_offset + pp]
-                    += imageCube[k][0].array.SI32[fifo_reading_offset[k] + pp];
+                image[0].base_array.SI32[fifo_writing_offset + pp]
+                    += imageCube[k][0].base_array.SI32[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->md[0].atype == _DATATYPE_UINT64)
+    else if (image->base_md[0].atype == _DATATYPE_UINT64)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.UI64[fifo_writing_offset + pp] = 0;
+            image[0].base_array.UI64[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.UI64[fifo_writing_offset + pp]
-                    += imageCube[k][0].array.UI64[fifo_reading_offset[k] + pp];
+                image[0].base_array.UI64[fifo_writing_offset + pp]
+                    += imageCube[k][0].base_array.UI64[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->md[0].atype == _DATATYPE_INT64)
+    else if (image->base_md[0].atype == _DATATYPE_INT64)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.SI64[fifo_writing_offset + pp] = 0;
+            image[0].base_array.SI64[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.SI64[fifo_writing_offset + pp]
-                    += imageCube[k][0].array.SI64[fifo_reading_offset[k] + pp];
+                image[0].base_array.SI64[fifo_writing_offset + pp]
+                    += imageCube[k][0].base_array.SI64[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->md[0].atype == _DATATYPE_FLOAT)
+    else if (image->base_md[0].atype == _DATATYPE_FLOAT)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.F[fifo_writing_offset + pp] = 0;
+            image[0].base_array.F[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.F[fifo_writing_offset + pp]
-                    += imageCube[k][0].array.F[fifo_reading_offset[k] + pp];
+                image[0].base_array.F[fifo_writing_offset + pp]
+                    += imageCube[k][0].base_array.F[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->md[0].atype == _DATATYPE_DOUBLE)
+    else if (image->base_md[0].atype == _DATATYPE_DOUBLE)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.D[fifo_writing_offset + pp] = 0;
+            image[0].base_array.D[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.D[fifo_writing_offset + pp]
-                    += imageCube[k][0].array.D[fifo_reading_offset[k] + pp];
+                image[0].base_array.D[fifo_writing_offset + pp]
+                    += imageCube[k][0].base_array.D[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
+    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_FLOAT)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.CF[fifo_writing_offset + pp].re = 0;
-            image[0].array.CF[fifo_writing_offset + pp].im = 0;
+            image[0].base_array.CF[fifo_writing_offset + pp].re = 0;
+            image[0].base_array.CF[fifo_writing_offset + pp].im = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.CF[fifo_writing_offset + pp].re
-                    += imageCube[k][0].array.CF[fifo_reading_offset[k] + pp].re;
-                image[0].array.CF[fifo_writing_offset + pp].im
-                    += imageCube[k][0].array.CF[fifo_reading_offset[k] + pp].im;
+                image[0].base_array.CF[fifo_writing_offset + pp].re
+                    += imageCube[k][0].base_array.CF[fifo_reading_offset[k] + pp].re;
+                image[0].base_array.CF[fifo_writing_offset + pp].im
+                    += imageCube[k][0].base_array.CF[fifo_reading_offset[k] + pp].im;
             }
         }
     }
-        else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
+        else if (image->base_md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].array.CD[fifo_writing_offset + pp].re = 0;
-            image[0].array.CD[fifo_writing_offset + pp].im = 0;
+            image[0].base_array.CD[fifo_writing_offset + pp].re = 0;
+            image[0].base_array.CD[fifo_writing_offset + pp].im = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].array.CD[fifo_writing_offset + pp].re
-                    += imageCube[k][0].array.CD[fifo_reading_offset[k] + pp].re;
-                image[0].array.CD[fifo_writing_offset + pp].im
-                    += imageCube[k][0].array.CD[fifo_reading_offset[k] + pp].im;
+                image[0].base_array.CD[fifo_writing_offset + pp].re
+                    += imageCube[k][0].base_array.CD[fifo_reading_offset[k] + pp].re;
+                image[0].base_array.CD[fifo_writing_offset + pp].im
+                    += imageCube[k][0].base_array.CD[fifo_reading_offset[k] + pp].im;
             }
         }
     }
@@ -2222,10 +2277,10 @@ int_fast8_t daoShmWaitForSemaphore(IMAGE *image, int32_t semNb)
     if (sem_wait(image->semptr[semNb]) == 0) 
     {
         // Safely decrement the counter, but only if > 0
-        unsigned int val = atomic_load(&image->md[0].semCounter[semNb]);
+        unsigned int val = atomic_load(&image->base_md[0].semCounter[semNb]);
         while (val > 0)
         {
-            if (atomic_compare_exchange_weak(&image->md[0].semCounter[semNb], &val, val - 1))
+            if (atomic_compare_exchange_weak(&image->base_md[0].semCounter[semNb], &val, val - 1))
                 break;
             // If CAS fails, val is updated, loop again
         }
@@ -2238,6 +2293,12 @@ int_fast8_t daoShmWaitForSemaphore(IMAGE *image, int32_t semNb)
 #else
     sem_wait(image->semptr[semNb]);
 #endif
+
+    // Update the current array pointer
+    IMAGE_PTR_UPDATE(image->base_md[0].atype, image->array, image->base_array,
+        image->base_md[0].fifo_last_written, image->base_md[0].nelement);
+
+    IMAGE_MD_PTR_UPDATE_IDX(image, image->base_md[0].fifo_last_written);
 
     return DAO_SUCCESS;
 }
@@ -2283,12 +2344,19 @@ int_fast8_t daoShmWaitForSemaphoreTimeout(IMAGE *image, int32_t semNb, const str
 
     while (now_ns < end_ns)
     {
-        unsigned int val = atomic_load(&image->md[0].semCounter[semNb]);
+        unsigned int val = atomic_load(&image->base_md[0].semCounter[semNb]);
         if (val > 0)
         {
             if (sem_wait(image->semptr[semNb]) == 0)
             {
-                atomic_fetch_sub(&image->md[0].semCounter[semNb], 1);
+                atomic_fetch_sub(&image->base_md[0].semCounter[semNb], 1);
+
+                // Update the current array pointer
+                IMAGE_PTR_UPDATE(image->base_md[0].atype, image->array, image->base_array,
+                    image->base_md[0].fifo_last_written, image->base_md[0].nelement);
+
+                IMAGE_MD_PTR_UPDATE_IDX(image, image->base_md[0].fifo_last_written);
+
                 return DAO_SUCCESS;
             }
             else
@@ -2314,6 +2382,12 @@ int_fast8_t daoShmWaitForSemaphoreTimeout(IMAGE *image, int32_t semNb, const str
     }
 #endif
 
+    // Update the current array pointer
+    IMAGE_PTR_UPDATE(image->base_md[0].atype, image->array, image->base_array,
+        image->base_md[0].fifo_last_written, image->base_md[0].nelement);
+
+    IMAGE_MD_PTR_UPDATE_IDX(image, image->base_md[0].fifo_last_written);
+
     return DAO_SUCCESS;
 }
 
@@ -2326,7 +2400,7 @@ int_fast8_t daoShmWaitForSemaphoreTimeout(IMAGE *image, int32_t semNb, const str
 int_fast8_t daoShmWaitForCounter(IMAGE *image)
 {
     daoTrace("\n");
-    volatile IMAGE_METADATA *md = (volatile IMAGE_METADATA *)image->md;
+    volatile IMAGE_METADATA *md = (volatile IMAGE_METADATA *)image->base_md;
 
     if (md->fifo_size == 1) // Spin on our only cnt0 for 1-deep images
     {
@@ -2337,7 +2411,7 @@ int_fast8_t daoShmWaitForCounter(IMAGE *image)
             // Spin
         }
     #else
-        uint_fast64_t counter = image->md[0].cnt0;
+        uint_fast64_t counter = image->base_md[0].cnt0;
         struct timespec req, rem;
         req.tv_sec = 0;          // Seconds
         req.tv_nsec = 0; // Nanoseconds
@@ -2375,10 +2449,16 @@ int_fast8_t daoShmWaitForCounter(IMAGE *image)
                 return DAO_ERROR;
             }
         }
-    #endif
+        #endif
+
+        // Update the current array pointer
+        IMAGE_PTR_UPDATE(image->base_md[0].atype, image->array, image->base_array,
+            fifo_position, image->base_md[0].nelement);
+
+        IMAGE_MD_PTR_UPDATE_IDX(image, fifo_position);
+
         return DAO_SUCCESS;
     }
-
 }
 
 /**
@@ -2396,7 +2476,7 @@ int_fast8_t daoShmWaitForTargetCounter(IMAGE *image, uint64_t targetCnt0)
     req.tv_sec = 0;          // Seconds
     req.tv_nsec = 0; // Nanoseconds
 
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
 
     if (vol_md->fifo_size == 1) // Spin on our only cnt0 for 1-deep images
     {
@@ -2429,6 +2509,12 @@ int_fast8_t daoShmWaitForTargetCounter(IMAGE *image, uint64_t targetCnt0)
         }
     }
 
+    // Update the current array pointer
+    IMAGE_PTR_UPDATE(image->base_md[0].atype, image->array, image->base_array,
+        image->base_md[0].fifo_last_written, image->base_md[0].nelement);
+
+    IMAGE_MD_PTR_UPDATE_IDX(image, image->base_md[0].fifo_last_written);
+
     return DAO_SUCCESS;
 }
 
@@ -2442,9 +2528,9 @@ uint_fast64_t daoShmGetCounter(IMAGE *image)
 {
     daoTrace("\n");
 
-    uint32_t fifo_last_written = image->md[0].fifo_last_written;
+    uint32_t fifo_last_written = image->base_md[0].fifo_last_written;
 
-    return image->md[fifo_last_written].cnt0;
+    return image->base_md[fifo_last_written].cnt0;
 }
 
 /**
@@ -2469,7 +2555,7 @@ int_fast8_t daoShmGetNextSegment(IMAGE *image, void** segment_ptr, uint32_t* seg
     int_fast8_t return_val = DAO_SUCCESS;
 
     volatile IMAGE *vol_image = (volatile IMAGE *)image;
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
 
     uint32_t last_read_idx  = vol_image->fifo_last_read;
     uint64_t last_read_cnt0 = vol_image->fifo_last_read_cnt0;
@@ -2492,37 +2578,41 @@ int_fast8_t daoShmGetNextSegment(IMAGE *image, void** segment_ptr, uint32_t* seg
     }
 
     // Set the segment pointer and index
-    if (image->md[0].atype == _DATATYPE_UINT8)
-        *segment_ptr = &(image->array.UI8[next_segment_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_INT8)
-        *segment_ptr = &(image->array.SI8[next_segment_idx * image->md[0].nelement]);      
-    else if (image->md[0].atype == _DATATYPE_UINT16)
-        *segment_ptr = &(image->array.UI16[next_segment_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_INT16)
-        *segment_ptr = &(image->array.SI16[next_segment_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_INT32)
-        *segment_ptr = &(image->array.UI32[next_segment_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_UINT32)
-        *segment_ptr = &(image->array.SI32[next_segment_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_UINT64)
-        *segment_ptr = &(image->array.UI64[next_segment_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_INT64)
-        *segment_ptr = &(image->array.SI64[next_segment_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_FLOAT)
-        *segment_ptr = &(image->array.F[next_segment_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_DOUBLE)
-        *segment_ptr = &(image->array.D[next_segment_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
-        *segment_ptr = &(image->array.CF[next_segment_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
-        *segment_ptr = &(image->array.CD[next_segment_idx * image->md[0].nelement]);
+    if (image->base_md[0].atype == _DATATYPE_UINT8)
+        *segment_ptr = &(image->base_array.UI8[next_segment_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_INT8)
+        *segment_ptr = &(image->base_array.SI8[next_segment_idx * image->base_md[0].nelement]);      
+    else if (image->base_md[0].atype == _DATATYPE_UINT16)
+        *segment_ptr = &(image->base_array.UI16[next_segment_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_INT16)
+        *segment_ptr = &(image->base_array.SI16[next_segment_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_INT32)
+        *segment_ptr = &(image->base_array.UI32[next_segment_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_UINT32)
+        *segment_ptr = &(image->base_array.SI32[next_segment_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_UINT64)
+        *segment_ptr = &(image->base_array.UI64[next_segment_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_INT64)
+        *segment_ptr = &(image->base_array.SI64[next_segment_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_FLOAT)
+        *segment_ptr = &(image->base_array.F[next_segment_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_DOUBLE)
+        *segment_ptr = &(image->base_array.D[next_segment_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_FLOAT)
+        *segment_ptr = &(image->base_array.CF[next_segment_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
+        *segment_ptr = &(image->base_array.CD[next_segment_idx * image->base_md[0].nelement]);
 
     *segment_idx = next_segment_idx;
     *segment_cnt0 = next_segment_cnt0;
 
     // Update the bookkeeping variables for this FIFO tail our IMAGE struct
-    vol_image->fifo_last_read = next_segment_idx;
-    vol_image->fifo_last_read_cnt0 = next_segment_cnt0;
+    image->fifo_last_read = next_segment_idx;
+    image->fifo_last_read_cnt0 = next_segment_cnt0;
+
+    IMAGE_PTR_UPDATE_DIRECT(image->array, segment_ptr);
+
+    IMAGE_MD_PTR_UPDATE_IDX(image, next_segment_idx);
 
     return return_val;
 }
@@ -2548,32 +2638,36 @@ int_fast8_t daoShmWaitForNextSegment(IMAGE *image)
  */
 int_fast8_t daoShmGetArbitrarySegment(IMAGE *image, void** segment_ptr, uint_fast32_t fifo_idx)
 {
-    uint32_t actual_idx = (uint32_t)(fifo_idx % image->md[0].fifo_size);
+    uint32_t actual_idx = (uint32_t)(fifo_idx % image->base_md[0].fifo_size);
 
-    if (image->md[0].atype == _DATATYPE_UINT8)
-        *segment_ptr = &(image->array.UI8[actual_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_INT8)
-        *segment_ptr = &(image->array.SI8[actual_idx * image->md[0].nelement]);      
-    else if (image->md[0].atype == _DATATYPE_UINT16)
-        *segment_ptr = &(image->array.UI16[actual_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_INT16)
-        *segment_ptr = &(image->array.SI16[actual_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_INT32)
-        *segment_ptr = &(image->array.UI32[actual_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_UINT32)
-        *segment_ptr = &(image->array.SI32[actual_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_UINT64)
-        *segment_ptr = &(image->array.UI64[actual_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_INT64)
-        *segment_ptr = &(image->array.SI64[actual_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_FLOAT)
-        *segment_ptr = &(image->array.F[actual_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_DOUBLE)
-        *segment_ptr = &(image->array.D[actual_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
-        *segment_ptr = &(image->array.CF[actual_idx * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
-        *segment_ptr = &(image->array.CD[actual_idx * image->md[0].nelement]);
+    if (image->base_md[0].atype == _DATATYPE_UINT8)
+        *segment_ptr = &(image->base_array.UI8[actual_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_INT8)
+        *segment_ptr = &(image->base_array.SI8[actual_idx * image->base_md[0].nelement]);      
+    else if (image->base_md[0].atype == _DATATYPE_UINT16)
+        *segment_ptr = &(image->base_array.UI16[actual_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_INT16)
+        *segment_ptr = &(image->base_array.SI16[actual_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_INT32)
+        *segment_ptr = &(image->base_array.UI32[actual_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_UINT32)
+        *segment_ptr = &(image->base_array.SI32[actual_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_UINT64)
+        *segment_ptr = &(image->base_array.UI64[actual_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_INT64)
+        *segment_ptr = &(image->base_array.SI64[actual_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_FLOAT)
+        *segment_ptr = &(image->base_array.F[actual_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_DOUBLE)
+        *segment_ptr = &(image->base_array.D[actual_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_FLOAT)
+        *segment_ptr = &(image->base_array.CF[actual_idx * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
+        *segment_ptr = &(image->base_array.CD[actual_idx * image->base_md[0].nelement]);
+
+    IMAGE_PTR_UPDATE_DIRECT(image->array, segment_ptr);
+
+    IMAGE_MD_PTR_UPDATE_IDX(image, actual_idx);
 
     return DAO_SUCCESS;
 }
@@ -2588,38 +2682,42 @@ int_fast8_t daoShmGetArbitrarySegment(IMAGE *image, void** segment_ptr, uint_fas
  */
 int_fast8_t daoShmGetNewestSegment(IMAGE *image, void** segment_ptr, uint32_t* segment_idx, uint64_t *segment_cnt0)
 {
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
 
     uint32_t last_written = vol_md[0].fifo_last_written;
     uint64_t cnt0 = vol_md[last_written].cnt0;
 
-    if (image->md[0].atype == _DATATYPE_UINT8)
-        *segment_ptr = &(image->array.UI8[last_written * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_INT8)
-        *segment_ptr = &(image->array.SI8[last_written * image->md[0].nelement]);      
-    else if (image->md[0].atype == _DATATYPE_UINT16)
-        *segment_ptr = &(image->array.UI16[last_written * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_INT16)
-        *segment_ptr = &(image->array.SI16[last_written * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_INT32)
-        *segment_ptr = &(image->array.UI32[last_written * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_UINT32)
-        *segment_ptr = &(image->array.SI32[last_written * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_UINT64)
-        *segment_ptr = &(image->array.UI64[last_written * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_INT64)
-        *segment_ptr = &(image->array.SI64[last_written * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_FLOAT)
-        *segment_ptr = &(image->array.F[last_written * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_DOUBLE)
-        *segment_ptr = &(image->array.D[last_written * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
-        *segment_ptr = &(image->array.CF[last_written * image->md[0].nelement]);
-    else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
-        *segment_ptr = &(image->array.CD[last_written * image->md[0].nelement]);
+    if (image->base_md[0].atype == _DATATYPE_UINT8)
+        *segment_ptr = &(image->base_array.UI8[last_written * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_INT8)
+        *segment_ptr = &(image->base_array.SI8[last_written * image->base_md[0].nelement]);      
+    else if (image->base_md[0].atype == _DATATYPE_UINT16)
+        *segment_ptr = &(image->base_array.UI16[last_written * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_INT16)
+        *segment_ptr = &(image->base_array.SI16[last_written * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_INT32)
+        *segment_ptr = &(image->base_array.UI32[last_written * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_UINT32)
+        *segment_ptr = &(image->base_array.SI32[last_written * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_UINT64)
+        *segment_ptr = &(image->base_array.UI64[last_written * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_INT64)
+        *segment_ptr = &(image->base_array.SI64[last_written * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_FLOAT)
+        *segment_ptr = &(image->base_array.F[last_written * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_DOUBLE)
+        *segment_ptr = &(image->base_array.D[last_written * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_FLOAT)
+        *segment_ptr = &(image->base_array.CF[last_written * image->base_md[0].nelement]);
+    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
+        *segment_ptr = &(image->base_array.CD[last_written * image->base_md[0].nelement]);
 
     *segment_idx = last_written;
     *segment_cnt0 = cnt0;
+
+    IMAGE_PTR_UPDATE_DIRECT(image->array, segment_ptr);
+
+    IMAGE_MD_PTR_UPDATE_IDX(image, last_written);
 
     return DAO_SUCCESS;
 }
@@ -2641,7 +2739,7 @@ int_fast8_t daoShmCheckSegmentOverwrite(IMAGE *image)
     int_fast8_t return_val = DAO_SUCCESS;
 
     volatile IMAGE *vol_image = (volatile IMAGE *)image;
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
 
     uint32_t last_read_idx = vol_image->fifo_last_read;
     uint64_t last_read_cnt0 = vol_image->fifo_last_read_cnt0;
@@ -2664,7 +2762,7 @@ int_fast8_t daoShmCheckSegmentOverwrite(IMAGE *image)
  */
 int_fast8_t daoShmResetTail(IMAGE *image, uint32_t* segment_idx, uint64_t *segment_cnt0)
 {
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
 
     uint32_t new_segment_idx = vol_md[0].fifo_last_written;
     uint64_t new_segment_cnt0 = vol_md[new_segment_idx].cnt0;
@@ -2674,6 +2772,12 @@ int_fast8_t daoShmResetTail(IMAGE *image, uint32_t* segment_idx, uint64_t *segme
 
     image->fifo_last_read = new_segment_idx;
     image->fifo_last_read_cnt0 = new_segment_cnt0;
+
+    // Update the current array pointer
+    IMAGE_PTR_UPDATE(image->base_md[0].atype, image->array, image->base_array,
+        new_segment_idx, image->base_md[0].nelement);
+
+    IMAGE_MD_PTR_UPDATE_IDX(image, new_segment_idx);
 
     return DAO_SUCCESS;
 }
@@ -2696,7 +2800,7 @@ int_fast8_t daoShmCloseShm(IMAGE *image)
 
     // Release all semaphores
     if (image->semptr) {
-        for(s = 0; s < image->md[0].sem; s++) {
+        for(s = 0; s < image->base_md[0].sem; s++) {
 #ifdef _WIN32
             if (image->semptr[s]) {
                 CloseHandle(image->semptr[s]);
@@ -2737,12 +2841,12 @@ int_fast8_t daoShmCloseShm(IMAGE *image)
     }
 
     // Unmap memory and close file descriptor if shared
-    if (image->md[0].shared) {
+    if (image->base_md[0].shared) {
 #ifdef _WIN32
         // Windows: Unmap the view and close handles
-        if (image->md) {
-            UnmapViewOfFile((LPVOID)image->md);
-            image->md = NULL;
+        if (image->base_md) {
+            UnmapViewOfFile((LPVOID)image->base_md);
+            image->base_md = NULL;
         }
         if (image->shmfm) {
             CloseHandle(image->shmfm);
@@ -2754,9 +2858,9 @@ int_fast8_t daoShmCloseShm(IMAGE *image)
         }
 #else
         // Unix: Unmap memory and close file descriptor
-        if (image->md) {
-            munmap(image->md, image->memsize);
-            image->md = NULL;
+        if (image->base_md) {
+            munmap(image->base_md, image->memsize);
+            image->base_md = NULL;
         }
         if (image->shmfd > 0) {
             close(image->shmfd);
@@ -2782,7 +2886,7 @@ int_fast8_t daoShmTimestampShm(IMAGE *image)
     struct timespec t;
     clock_gettime(CLOCK_REALTIME, &t);
 
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
 
     uint32_t fifo_last_written = vol_md[0].fifo_last_written;
     uint32_t fifo_prior_write = (fifo_last_written == 0)
@@ -2809,24 +2913,24 @@ int_fast8_t daoSemPost(IMAGE *image, int32_t semNb)
 #ifdef _WIN32
     ReleaseSemaphore(image->semptr[semNb], 1, NULL);
 #elif defined(__APPLE__)
-    unsigned int oldval = atomic_load(&image->md[0].semCounter[semNb]);
+    unsigned int oldval = atomic_load(&image->base_md[0].semCounter[semNb]);
 
     while (oldval < SEMAPHORE_MAXVAL)
     {
         // Try to increment semCounter atomically
-        if (atomic_compare_exchange_weak(&image->md[0].semCounter[semNb], &oldval, oldval + 1))
+        if (atomic_compare_exchange_weak(&image->base_md[0].semCounter[semNb], &oldval, oldval + 1))
         {
             // Only post if we managed to reserve a "slot" in semCounter
             if (sem_post(image->semptr[semNb]) == 0)
             {
                 daoDebug("Posted sem %d, new semCounter = %u (pid=%d)\n",
-                         semNb, atomic_load(&image->md[0].semCounter[semNb]), getpid());
+                         semNb, atomic_load(&image->base_md[0].semCounter[semNb]), getpid());
                 return DAO_SUCCESS;
             }
             else
             {
                 // Rollback the counter change
-                atomic_fetch_sub(&image->md[0].semCounter[semNb], 1);
+                atomic_fetch_sub(&image->base_md[0].semCounter[semNb], 1);
                 daoError("sem_post failed on sem %d: %s\n", semNb, strerror(errno));
                 return DAO_ERROR;
             }
@@ -2856,7 +2960,7 @@ int_fast8_t daoSemPostAll(IMAGE *image)
 {
     daoTrace("\n");
     int ss;
-    for(ss = 0; ss < image->md[0].sem; ss++)
+    for(ss = 0; ss < image->base_md[0].sem; ss++)
     {
         daoSemPost(image, ss);
     }
@@ -2876,12 +2980,12 @@ int_fast8_t daoSemLogPost(IMAGE *image)
 #ifdef _WIN32
     ReleaseSemaphore(image->semlog, 1, NULL);
 #elif defined(__APPLE__)
-    unsigned int val = atomic_load(&image->md[0].semLogCounter);
+    unsigned int val = atomic_load(&image->base_md[0].semLogCounter);
     if (val < SEMAPHORE_MAXVAL)
     {
         if (sem_post(image->semlog) == 0)
         {
-            atomic_fetch_add(&image->md[0].semLogCounter, 1);
+            atomic_fetch_add(&image->base_md[0].semLogCounter, 1);
         }
         else
         {

--- a/src/c/dao.c
+++ b/src/c/dao.c
@@ -87,41 +87,6 @@ static int clock_gettime(int clk_id, struct timespec *t)
 #include "dao.h"
 static int current_log_level = DEFAULT_LOG_LEVEL;
 
-#define IMAGE_PTR_UPDATE(atype, array, base_array, idx, nelement) { \
-    if ((atype) == _DATATYPE_UINT8) \
-        (array).UI8 = &((base_array).UI8[(idx) * (nelement)]); \
-    else if (atype == _DATATYPE_INT8) \
-        (array).SI8 = &((base_array).SI8[(idx) * (nelement)]); \
-    else if (atype == _DATATYPE_UINT16) \
-        (array).UI16 = &((base_array).UI16[(idx) * (nelement)]); \
-    else if (atype == _DATATYPE_INT16) \
-        (array).SI16 = &((base_array).SI16[(idx) * (nelement)]); \
-    else if (atype == _DATATYPE_INT32) \
-        (array).UI32 = &((base_array).UI32[(idx) * (nelement)]); \
-    else if (atype == _DATATYPE_UINT32) \
-        (array).SI32 = &((base_array).SI32[(idx) * (nelement)]); \
-    else if (atype == _DATATYPE_UINT64) \
-        (array).UI64 = &((base_array).UI64[(idx) * (nelement)]); \
-    else if (atype == _DATATYPE_INT64) \
-        (array).SI64 = &((base_array).SI64[(idx) * (nelement)]); \
-    else if (atype == _DATATYPE_FLOAT) \
-        (array).F = &((base_array).F[(idx) * (nelement)]); \
-    else if (atype == _DATATYPE_DOUBLE) \
-        (array).D = &((base_array).D[(idx) * (nelement)]); \
-    else if (atype == _DATATYPE_COMPLEX_FLOAT) \
-        (array).CF = &((base_array).CF[(idx) * (nelement)]); \
-    else if (atype == _DATATYPE_COMPLEX_DOUBLE) \
-        (array).CD = &((base_array).CD[(idx) * (nelement)]); \
-}
-
-#define IMAGE_PTR_UPDATE_DIRECT(array, new_ptr) { \
-    (array).V = (void*)new_ptr; \
-}
-
-#define IMAGE_MD_PTR_UPDATE_IDX(image, new_md_idx) { \
-    image->md = &(image->base_md[new_md_idx]); \
-}
-
 /**
  * @brief Return a time stamp string with microsecond precision 
  * 
@@ -577,7 +542,7 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
 		image->memsize = (int64_t)fileSizeLow | ((int64_t)fileSizeHigh << 32);
 		image->shmfd = shmFd;
 		image->shmfm = shmFm;
-		image->base_md = map;
+		image->md = map;
 
 #else
 		
@@ -598,29 +563,29 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
 
         image->memsize = file_stat.st_size;
         image->shmfd = shmFd;
-        image->base_md = map;
-        //        image->base_md[0].sem = 0;
+        image->md = map;
+        //        image->md[0].sem = 0;
 
 #endif
-        atype = image->base_md[0].atype;
-        image->base_md[0].shared = 1;
+        atype = image->md[0].atype;
+        image->md[0].shared = 1;
 
-        daoDebug("image size = %ld %ld\n", (long) image->base_md[0].size[0], (long) image->base_md[0].size[1]);
+        daoDebug("image size = %ld %ld\n", (long) image->md[0].size[0], (long) image->md[0].size[1]);
         fflush(stdout);
         // some verification
-//        if(image->base_md[0].size[0]*image->base_md[0].size[1]>10000000000)
+//        if(image->md[0].size[0]*image->md[0].size[1]>10000000000)
 //        {
 //            daoDebug("IMAGE \"%s\" SEEMS BIG... ABORTING\n", name);
 //            rval = DAO_ERROR;
 //            exit(0);
 //        }
-        if(image->base_md[0].size[0]<1)
+        if(image->md[0].size[0]<1)
         {
             daoError("IMAGE \"%s\" AXIS SIZE < 1... ABORTING\n", name);
             rval = DAO_ERROR;
             exit(0);
         }
-        if(image->base_md[0].size[1]<1)
+        if(image->md[0].size[1]<1)
         {
             daoError("IMAGE \"%s\" AXIS SIZE < 1... ABORTING\n", name);
             rval = DAO_ERROR;
@@ -629,7 +594,7 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
 
         /* Get the size of the FIFO */
 
-        fifo_size = image->base_md[0].fifo_size;
+        fifo_size = image->md[0].fifo_size;
 
         mapv = (char*) map;
         mapv += fifo_size * sizeof(IMAGE_METADATA);
@@ -640,80 +605,80 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
         if(atype == _DATATYPE_UINT8)
         {
             daoDebug("atype = UINT8\n");
-            image->base_array.UI8 = (uint8_t*) mapv;
-            mapv += SIZEOF_DATATYPE_UINT8 * fifo_size * image->base_md[0].nelement;
+            image->array.UI8 = (uint8_t*) mapv;
+            mapv += SIZEOF_DATATYPE_UINT8 * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_INT8)
         {
             daoDebug("atype = INT8\n");
-            image->base_array.SI8 = (int8_t*) mapv;
-            mapv += SIZEOF_DATATYPE_INT8 * fifo_size * image->base_md[0].nelement;
+            image->array.SI8 = (int8_t*) mapv;
+            mapv += SIZEOF_DATATYPE_INT8 * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_UINT16)
         {
             daoDebug("atype = UINT16\n");
-            image->base_array.UI16 = (uint16_t*) mapv;
-            mapv += SIZEOF_DATATYPE_UINT16 * fifo_size * image->base_md[0].nelement;
+            image->array.UI16 = (uint16_t*) mapv;
+            mapv += SIZEOF_DATATYPE_UINT16 * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_INT16)
         {
             daoDebug("atype = INT16\n");
-            image->base_array.SI16 = (int16_t*) mapv;
-            mapv += SIZEOF_DATATYPE_INT16 * fifo_size * image->base_md[0].nelement;
+            image->array.SI16 = (int16_t*) mapv;
+            mapv += SIZEOF_DATATYPE_INT16 * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_UINT32)
         {
             daoDebug("atype = UINT32\n");
-            image->base_array.UI32 = (uint32_t*) mapv;
-            mapv += SIZEOF_DATATYPE_UINT32 * fifo_size * image->base_md[0].nelement;
+            image->array.UI32 = (uint32_t*) mapv;
+            mapv += SIZEOF_DATATYPE_UINT32 * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_INT32)
         {
             daoDebug("atype = INT32\n");
-            image->base_array.SI32 = (int32_t*) mapv;
-            mapv += SIZEOF_DATATYPE_INT32 * fifo_size * image->base_md[0].nelement;
+            image->array.SI32 = (int32_t*) mapv;
+            mapv += SIZEOF_DATATYPE_INT32 * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_UINT64)
         {
             daoDebug("atype = UINT64\n");
-            image->base_array.UI64 = (uint64_t*) mapv;
-            mapv += SIZEOF_DATATYPE_UINT64 * fifo_size * image->base_md[0].nelement;
+            image->array.UI64 = (uint64_t*) mapv;
+            mapv += SIZEOF_DATATYPE_UINT64 * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_INT64)
         {
             daoDebug("atype = INT64\n");
-            image->base_array.SI64 = (int64_t*) mapv;
-            mapv += SIZEOF_DATATYPE_INT64 * fifo_size * image->base_md[0].nelement;
+            image->array.SI64 = (int64_t*) mapv;
+            mapv += SIZEOF_DATATYPE_INT64 * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_FLOAT)
         {
             daoDebug("atype = FLOAT\n");
-            image->base_array.F = (float*) mapv;
-            mapv += SIZEOF_DATATYPE_FLOAT * fifo_size * image->base_md[0].nelement;
+            image->array.F = (float*) mapv;
+            mapv += SIZEOF_DATATYPE_FLOAT * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_DOUBLE)
         {
             daoDebug("atype = DOUBLE\n");
-            image->base_array.D = (double*) mapv;
-            mapv += SIZEOF_DATATYPE_DOUBLE * fifo_size * image->base_md[0].nelement;
+            image->array.D = (double*) mapv;
+            mapv += SIZEOF_DATATYPE_DOUBLE * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_COMPLEX_FLOAT)
         {
             daoDebug("atype = COMPLEX_FLOAT\n");
-            image->base_array.CF = (complex_float*) mapv;
-            mapv += SIZEOF_DATATYPE_COMPLEX_FLOAT * fifo_size * image->base_md[0].nelement;
+            image->array.CF = (complex_float*) mapv;
+            mapv += SIZEOF_DATATYPE_COMPLEX_FLOAT * fifo_size * image->md[0].nelement;
         }
         if(atype == _DATATYPE_COMPLEX_DOUBLE)
         {
             daoDebug("atype = COMPLEX_DOUBLE\n");
-            image->base_array.CD = (complex_double*) mapv;
-            mapv += SIZEOF_DATATYPE_COMPLEX_DOUBLE * fifo_size * image->base_md[0].nelement;
+            image->array.CD = (complex_double*) mapv;
+            mapv += SIZEOF_DATATYPE_COMPLEX_DOUBLE * fifo_size * image->md[0].nelement;
         }
-        daoDebug("%ld keywords\n", (long) image->base_md[0].NBkw);
+        daoDebug("%ld keywords\n", (long) image->md[0].NBkw);
         fflush(stdout);
 
         image->kw = (IMAGE_KEYWORD*) (mapv);
-        for(kw=0; kw<image->base_md[0].NBkw; kw++)
+        for(kw=0; kw<image->md[0].NBkw; kw++)
         {
             if(image->kw[kw].type == 'L')
                 #if defined(_WIN32) || defined(__APPLE__)
@@ -727,7 +692,7 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
                 daoDebug("%d  %s %s %s\n", kw, image->kw[kw].name, image->kw[kw].value.valstr, image->kw[kw].comment);
         }
 
-        mapv += sizeof(IMAGE_KEYWORD)*image->base_md[0].NBkw;
+        mapv += sizeof(IMAGE_KEYWORD)*image->md[0].NBkw;
         strcpy(image->name, name);
         // to get rid off warning
         char * nameCopy = (char *)malloc((strlen(name)+1)*sizeof(char));
@@ -801,9 +766,9 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
                 snb++;
             }
 		}
-        daoDebug("%ld semaphores detected  (image->base_md[0].sem = %d)\n", snb, (int) image->base_md[0].sem);
-        //        image->base_md[0].sem = snb;
-        image->semptr = (HANDLE*) malloc(sizeof(HANDLE) * image->base_md[0].sem);
+        daoDebug("%ld semaphores detected  (image->md[0].sem = %d)\n", snb, (int) image->md[0].sem);
+        //        image->md[0].sem = snb;
+        image->semptr = (HANDLE*) malloc(sizeof(HANDLE) * image->md[0].sem);
         for(s=0; s<snb; s++)
         {
             sprintf(shmSemName, "Local\\DAO_%s_sem%02ld", localName, s);
@@ -843,9 +808,9 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
                 snb++;
             }
         }
-        daoDebug("%ld semaphores detected  (image->base_md[0].sem = %d)\n", snb, (int) image->base_md[0].sem);
-        //        image->base_md[0].sem = snb;
-        image->semptr = (sem_t**) malloc(sizeof(sem_t*) * image->base_md[0].sem);
+        daoDebug("%ld semaphores detected  (image->md[0].sem = %d)\n", snb, (int) image->md[0].sem);
+        //        image->md[0].sem = snb;
+        image->semptr = (sem_t**) malloc(sizeof(sem_t*) * image->md[0].sem);
         for(s=0; s<snb; s++)
         {
             sprintf(shmSemName, "%s_sem%02ld", localName, s);
@@ -865,15 +830,9 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
 
         // Set up FIFO tail
 
-        uint32_t tail_idx;
-        uint64_t tail_cnt0;
-        daoShmResetTail(image, &tail_idx, &tail_cnt0);
-
-        // Set up array pointer for writing the one after our current position - this step is crucial for SHM writers, and
-        // has no effect on SHM reading, as long as the application always calls wait before the update
-
-        tail_idx = ((tail_idx + 1) >= image->base_md[0].fifo_size) ? 0 : tail_idx + 1;
-        IMAGE_MD_PTR_UPDATE_IDX(image, tail_idx);
+        uint32_t tmp32;
+        uint64_t tmp64;
+        daoShmResetTail(image, &tmp32, &tmp64);
     }
     return(rval);
 }
@@ -923,39 +882,39 @@ int_fast8_t daoShmImage2Shm(void *im, uint32_t nbVal, IMAGE *image)
 {
     daoTrace("\n");
 
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
 
     uint32_t last_written = vol_md[0].fifo_last_written;
-    uint32_t writing_idx = (last_written + 1) % (image->base_md[0].fifo_size);
+    uint32_t writing_idx = (last_written + 1) % (image->md[0].fifo_size);
 
-    uint64_t fifo_writing_offset = image->base_md[0].nelement * (uint64_t)writing_idx;
+    uint64_t fifo_writing_offset = image->md[0].nelement * (uint64_t)writing_idx;
 
     vol_md[writing_idx].write = 1;
 
-    if (image->base_md[writing_idx].atype == _DATATYPE_UINT8)
-        memcpy(&image->base_array.UI8[fifo_writing_offset], (unsigned char *)im, nbVal*sizeof(unsigned char)); 
-    else if (image->base_md[writing_idx].atype == _DATATYPE_INT8)
-        memcpy(&image->base_array.SI8[fifo_writing_offset], (char *)im, nbVal*sizeof(char));       
-    else if (image->base_md[writing_idx].atype == _DATATYPE_UINT16)
-        memcpy(&image->base_array.UI16[fifo_writing_offset], (unsigned short *)im, nbVal*sizeof(unsigned short));
-    else if (image->base_md[writing_idx].atype == _DATATYPE_INT16)
-        memcpy(&image->base_array.SI16[fifo_writing_offset], (short *)im, nbVal*sizeof(short));
-    else if (image->base_md[writing_idx].atype == _DATATYPE_INT32)
-        memcpy(&image->base_array.UI32[fifo_writing_offset], (unsigned int *)im, nbVal*sizeof(unsigned int));
-    else if (image->base_md[writing_idx].atype == _DATATYPE_UINT32)
-        memcpy(&image->base_array.SI32[fifo_writing_offset], (int *)im, nbVal*sizeof(int));
-    else if (image->base_md[writing_idx].atype == _DATATYPE_UINT64)
-        memcpy(&image->base_array.UI64[fifo_writing_offset], (unsigned long *)im, nbVal*sizeof(unsigned long));
-    else if (image->base_md[writing_idx].atype == _DATATYPE_INT64)
-        memcpy(&image->base_array.SI64[fifo_writing_offset], (long *)im, nbVal*sizeof(long));
-    else if (image->base_md[writing_idx].atype == _DATATYPE_FLOAT)
-        memcpy(&image->base_array.F[fifo_writing_offset], (float *)im, nbVal*sizeof(float));
-    else if (image->base_md[writing_idx].atype == _DATATYPE_DOUBLE)
-        memcpy(&image->base_array.D[fifo_writing_offset], (double *)im, nbVal*sizeof(double));
-    else if (image->base_md[writing_idx].atype == _DATATYPE_COMPLEX_FLOAT)
-        memcpy(&image->base_array.CF[fifo_writing_offset], (complex_float *)im, nbVal*sizeof(complex_float));
-    else if (image->base_md[writing_idx].atype == _DATATYPE_COMPLEX_DOUBLE)
-        memcpy(&image->base_array.CD[fifo_writing_offset], (complex_double *)im, nbVal*sizeof(complex_double));
+    if (image->md[writing_idx].atype == _DATATYPE_UINT8)
+        memcpy(&image->array.UI8[fifo_writing_offset], (unsigned char *)im, nbVal*sizeof(unsigned char)); 
+    else if (image->md[writing_idx].atype == _DATATYPE_INT8)
+        memcpy(&image->array.SI8[fifo_writing_offset], (char *)im, nbVal*sizeof(char));       
+    else if (image->md[writing_idx].atype == _DATATYPE_UINT16)
+        memcpy(&image->array.UI16[fifo_writing_offset], (unsigned short *)im, nbVal*sizeof(unsigned short));
+    else if (image->md[writing_idx].atype == _DATATYPE_INT16)
+        memcpy(&image->array.SI16[fifo_writing_offset], (short *)im, nbVal*sizeof(short));
+    else if (image->md[writing_idx].atype == _DATATYPE_INT32)
+        memcpy(&image->array.UI32[fifo_writing_offset], (unsigned int *)im, nbVal*sizeof(unsigned int));
+    else if (image->md[writing_idx].atype == _DATATYPE_UINT32)
+        memcpy(&image->array.SI32[fifo_writing_offset], (int *)im, nbVal*sizeof(int));
+    else if (image->md[writing_idx].atype == _DATATYPE_UINT64)
+        memcpy(&image->array.UI64[fifo_writing_offset], (unsigned long *)im, nbVal*sizeof(unsigned long));
+    else if (image->md[writing_idx].atype == _DATATYPE_INT64)
+        memcpy(&image->array.SI64[fifo_writing_offset], (long *)im, nbVal*sizeof(long));
+    else if (image->md[writing_idx].atype == _DATATYPE_FLOAT)
+        memcpy(&image->array.F[fifo_writing_offset], (float *)im, nbVal*sizeof(float));
+    else if (image->md[writing_idx].atype == _DATATYPE_DOUBLE)
+        memcpy(&image->array.D[fifo_writing_offset], (double *)im, nbVal*sizeof(double));
+    else if (image->md[writing_idx].atype == _DATATYPE_COMPLEX_FLOAT)
+        memcpy(&image->array.CF[fifo_writing_offset], (complex_float *)im, nbVal*sizeof(complex_float));
+    else if (image->md[writing_idx].atype == _DATATYPE_COMPLEX_DOUBLE)
+        memcpy(&image->array.CD[fifo_writing_offset], (complex_double *)im, nbVal*sizeof(complex_double));
 
     daoShmImagePart2ShmFinalize(image);
 
@@ -969,41 +928,41 @@ int_fast8_t daoShmImage2ShmQuiet(void *im, uint32_t nbVal, IMAGE *image)
 {
     daoTrace("\n");
 
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
 
     uint32_t last_written = vol_md[0].fifo_last_written;
-    uint32_t writing_idx = (last_written + 1) % (image->base_md[0].fifo_size);
+    uint32_t writing_idx = (last_written + 1) % (image->md[0].fifo_size);
 
-    uint64_t fifo_writing_offset = image->base_md[0].nelement * (uint64_t)writing_idx;
+    uint64_t fifo_writing_offset = image->md[0].nelement * (uint64_t)writing_idx;
 
-    image->base_md[writing_idx].write = 1;
+    image->md[writing_idx].write = 1;
 
-    if (image->base_md[0].atype == _DATATYPE_UINT8)
-        memcpy(&image->base_array.UI8[fifo_writing_offset], (unsigned char *)im, nbVal*sizeof(unsigned char)); 
-    else if (image->base_md[0].atype == _DATATYPE_INT8)
-        memcpy(&image->base_array.SI8[fifo_writing_offset], (char *)im, nbVal*sizeof(char));       
-    else if (image->base_md[0].atype == _DATATYPE_UINT16)
-        memcpy(&image->base_array.UI16[fifo_writing_offset], (unsigned short *)im, nbVal*sizeof(unsigned short));
-    else if (image->base_md[0].atype == _DATATYPE_INT16)
-        memcpy(&image->base_array.SI16[fifo_writing_offset], (short *)im, nbVal*sizeof(short));
-    else if (image->base_md[0].atype == _DATATYPE_INT32)
-        memcpy(&image->base_array.UI32[fifo_writing_offset], (unsigned int *)im, nbVal*sizeof(unsigned int));
-    else if (image->base_md[0].atype == _DATATYPE_UINT32)
-        memcpy(&image->base_array.SI32[fifo_writing_offset], (int *)im, nbVal*sizeof(int));
-    else if (image->base_md[0].atype == _DATATYPE_UINT64)
-        memcpy(&image->base_array.UI64[fifo_writing_offset], (unsigned long *)im, nbVal*sizeof(unsigned long));
-    else if (image->base_md[0].atype == _DATATYPE_INT64)
-        memcpy(&image->base_array.SI64[fifo_writing_offset], (long *)im, nbVal*sizeof(long));
-    else if (image->base_md[0].atype == _DATATYPE_FLOAT)
-        memcpy(&image->base_array.F[fifo_writing_offset], (float *)im, nbVal*sizeof(float));
-    else if (image->base_md[0].atype == _DATATYPE_DOUBLE)
-        memcpy(&image->base_array.D[fifo_writing_offset], (double *)im, nbVal*sizeof(double));
-    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_FLOAT)
-        memcpy(&image->base_array.CF[fifo_writing_offset], (complex_float *)im, nbVal*sizeof(complex_float));
-    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
-        memcpy(&image->base_array.CD[fifo_writing_offset], (complex_double *)im, nbVal*sizeof(complex_double));
+    if (image->md[0].atype == _DATATYPE_UINT8)
+        memcpy(&image->array.UI8[fifo_writing_offset], (unsigned char *)im, nbVal*sizeof(unsigned char)); 
+    else if (image->md[0].atype == _DATATYPE_INT8)
+        memcpy(&image->array.SI8[fifo_writing_offset], (char *)im, nbVal*sizeof(char));       
+    else if (image->md[0].atype == _DATATYPE_UINT16)
+        memcpy(&image->array.UI16[fifo_writing_offset], (unsigned short *)im, nbVal*sizeof(unsigned short));
+    else if (image->md[0].atype == _DATATYPE_INT16)
+        memcpy(&image->array.SI16[fifo_writing_offset], (short *)im, nbVal*sizeof(short));
+    else if (image->md[0].atype == _DATATYPE_INT32)
+        memcpy(&image->array.UI32[fifo_writing_offset], (unsigned int *)im, nbVal*sizeof(unsigned int));
+    else if (image->md[0].atype == _DATATYPE_UINT32)
+        memcpy(&image->array.SI32[fifo_writing_offset], (int *)im, nbVal*sizeof(int));
+    else if (image->md[0].atype == _DATATYPE_UINT64)
+        memcpy(&image->array.UI64[fifo_writing_offset], (unsigned long *)im, nbVal*sizeof(unsigned long));
+    else if (image->md[0].atype == _DATATYPE_INT64)
+        memcpy(&image->array.SI64[fifo_writing_offset], (long *)im, nbVal*sizeof(long));
+    else if (image->md[0].atype == _DATATYPE_FLOAT)
+        memcpy(&image->array.F[fifo_writing_offset], (float *)im, nbVal*sizeof(float));
+    else if (image->md[0].atype == _DATATYPE_DOUBLE)
+        memcpy(&image->array.D[fifo_writing_offset], (double *)im, nbVal*sizeof(double));
+    else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
+        memcpy(&image->array.CF[fifo_writing_offset], (complex_float *)im, nbVal*sizeof(complex_float));
+    else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
+        memcpy(&image->array.CD[fifo_writing_offset], (complex_double *)im, nbVal*sizeof(complex_double));
 	
-    image->base_md[writing_idx].write = 0;
+    image->md[writing_idx].write = 0;
 
     return DAO_SUCCESS;
 }
@@ -1017,48 +976,48 @@ int_fast8_t daoShmImagePart2Shm(char *im, uint32_t nbVal, IMAGE *image, uint32_t
 {
     daoTrace("\n");
 
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
 
     uint32_t last_written = vol_md[0].fifo_last_written;
-    uint32_t writing_idx = (last_written + 1) % (image->base_md[0].fifo_size);
+    uint32_t writing_idx = (last_written + 1) % (image->md[0].fifo_size);
 
-    uint64_t fifo_writing_offset = image->base_md[0].nelement * (uint64_t)writing_idx;
+    uint64_t fifo_writing_offset = image->md[0].nelement * (uint64_t)writing_idx;
 
     uint64_t adjusted_position = (uint64_t)position + fifo_writing_offset;
 
-    image->base_md[writing_idx].write = 1;
+    image->md[writing_idx].write = 1;
 
-    if (image->base_md[0].atype == _DATATYPE_UINT8)
-        memcpy(&image->base_array.UI8[adjusted_position], (unsigned char *)im, nbVal*sizeof(unsigned char)); 
-    else if (image->base_md[0].atype == _DATATYPE_INT8)
-        memcpy(&image->base_array.SI8[adjusted_position], (char *)im, nbVal*sizeof(char));       
-    else if (image->base_md[0].atype == _DATATYPE_UINT16)
-        memcpy(&image->base_array.UI16[adjusted_position], (unsigned short *)im, nbVal*sizeof(unsigned short));
-    else if (image->base_md[0].atype == _DATATYPE_INT16)
-        memcpy(&image->base_array.SI16[adjusted_position], (short *)im, nbVal*sizeof(short));
-    else if (image->base_md[0].atype == _DATATYPE_INT32)
-        memcpy(&image->base_array.UI32[adjusted_position], (unsigned int *)im, nbVal*sizeof(unsigned int));
-    else if (image->base_md[0].atype == _DATATYPE_UINT32)
-        memcpy(&image->base_array.SI32[adjusted_position], (int *)im, nbVal*sizeof(int));
-    else if (image->base_md[0].atype == _DATATYPE_UINT64)
-        memcpy(&image->base_array.UI64[adjusted_position], (unsigned long *)im, nbVal*sizeof(unsigned long));
-    else if (image->base_md[0].atype == _DATATYPE_INT64)
-        memcpy(&image->base_array.SI64[adjusted_position], (long *)im, nbVal*sizeof(long));
-    else if (image->base_md[0].atype == _DATATYPE_FLOAT)
-        memcpy(&image->base_array.F[adjusted_position], (float *)im, nbVal*sizeof(float));
-    else if (image->base_md[0].atype == _DATATYPE_DOUBLE)
-        memcpy(&image->base_array.D[adjusted_position], (double *)im, nbVal*sizeof(double));
-    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_FLOAT)
-        memcpy(&image->base_array.CF[adjusted_position], (complex_float *)im, nbVal*sizeof(complex_float));
-    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
-        memcpy(&image->base_array.CD[adjusted_position], (complex_double *)im, nbVal*sizeof(complex_double));
+    if (image->md[0].atype == _DATATYPE_UINT8)
+        memcpy(&image->array.UI8[adjusted_position], (unsigned char *)im, nbVal*sizeof(unsigned char)); 
+    else if (image->md[0].atype == _DATATYPE_INT8)
+        memcpy(&image->array.SI8[adjusted_position], (char *)im, nbVal*sizeof(char));       
+    else if (image->md[0].atype == _DATATYPE_UINT16)
+        memcpy(&image->array.UI16[adjusted_position], (unsigned short *)im, nbVal*sizeof(unsigned short));
+    else if (image->md[0].atype == _DATATYPE_INT16)
+        memcpy(&image->array.SI16[adjusted_position], (short *)im, nbVal*sizeof(short));
+    else if (image->md[0].atype == _DATATYPE_INT32)
+        memcpy(&image->array.UI32[adjusted_position], (unsigned int *)im, nbVal*sizeof(unsigned int));
+    else if (image->md[0].atype == _DATATYPE_UINT32)
+        memcpy(&image->array.SI32[adjusted_position], (int *)im, nbVal*sizeof(int));
+    else if (image->md[0].atype == _DATATYPE_UINT64)
+        memcpy(&image->array.UI64[adjusted_position], (unsigned long *)im, nbVal*sizeof(unsigned long));
+    else if (image->md[0].atype == _DATATYPE_INT64)
+        memcpy(&image->array.SI64[adjusted_position], (long *)im, nbVal*sizeof(long));
+    else if (image->md[0].atype == _DATATYPE_FLOAT)
+        memcpy(&image->array.F[adjusted_position], (float *)im, nbVal*sizeof(float));
+    else if (image->md[0].atype == _DATATYPE_DOUBLE)
+        memcpy(&image->array.D[adjusted_position], (double *)im, nbVal*sizeof(double));
+    else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
+        memcpy(&image->array.CF[adjusted_position], (complex_float *)im, nbVal*sizeof(complex_float));
+    else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
+        memcpy(&image->array.CD[adjusted_position], (complex_double *)im, nbVal*sizeof(complex_double));
 
-    image->base_md[writing_idx].lastPos = position;
-    image->base_md[writing_idx].lastNb = nbVal;
-    image->base_md[writing_idx].packetNb = packetId;
-    image->base_md[writing_idx].packetTotal = packetTotal;
-    image->base_md[writing_idx].lastNbArray[packetId] = frameNumber;
-    image->base_md[writing_idx].write = 0;
+    image->md[writing_idx].lastPos = position;
+    image->md[writing_idx].lastNb = nbVal;
+    image->md[writing_idx].packetNb = packetId;
+    image->md[writing_idx].packetTotal = packetTotal;
+    image->md[writing_idx].lastNbArray[packetId] = frameNumber;
+    image->md[writing_idx].write = 0;
 
     return DAO_SUCCESS;
 }
@@ -1071,18 +1030,14 @@ int_fast8_t daoShmImagePart2ShmFinalize(IMAGE *image)
 {
     daoTrace("\n");
 
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
 
     uint32_t last_written = vol_md[0].fifo_last_written;
-    uint32_t writing_idx = (last_written + 1) % (image->base_md[0].fifo_size);
+    uint32_t writing_idx = (last_written + 1) % (image->md[0].fifo_size);
 
-    // idx to update current image array pointer with (for FIFO compatibility)
-    uint32_t next_writing_idx = ((writing_idx + 1) < image->base_md[0].fifo_size) ?
-        writing_idx + 1 : 0;
+    image->md[writing_idx].write = 0;
 
-    image->base_md[writing_idx].write = 0;
-
-    image->base_md[0].fifo_last_written = writing_idx;
+    image->md[0].fifo_last_written = writing_idx;
 
     daoShmTimestampShm(image);
     daoSemPostAll(image);
@@ -1091,11 +1046,7 @@ int_fast8_t daoShmImagePart2ShmFinalize(IMAGE *image)
     {
         daoSemLogPost(image);
     }
-
-    IMAGE_PTR_UPDATE(image->base_md[0].atype, image->array, image->base_array,
-        next_writing_idx, image->base_md[0].nelement);
-    
-    IMAGE_MD_PTR_UPDATE_IDX(image, next_writing_idx);
+	 
 
     return DAO_SUCCESS;
 }
@@ -1125,14 +1076,14 @@ int_fast8_t daoImageCreateSem(IMAGE *image, long NBsem)
 #endif
 
 	//printf("%p\n", image);
-	//printf("%p\n", &(image->base_md[0]));
-	//printf("%p\n", &(image->base_md[0].name));
-	//printf("%s\n", image->base_md[0].name);
+	//printf("%p\n", &(image->md[0]));
+	//printf("%p\n", &(image->md[0].name));
+	//printf("%s\n", image->md[0].name);
 	//printf("%p\n", &strlen);
 
     // to get rid off warning
-    char * nameCopy = (char *)malloc((strlen(image->base_md[0].name)+1)*sizeof(char));
-    strcpy(nameCopy, image->base_md[0].name);
+    char * nameCopy = (char *)malloc((strlen(image->md[0].name)+1)*sizeof(char));
+    strcpy(nameCopy, image->md[0].name);
 	
     char *token = strtok(nameCopy, PATH_SEPARATOR);
 
@@ -1176,30 +1127,30 @@ int_fast8_t daoImageCreateSem(IMAGE *image, long NBsem)
 		return DAO_ERROR;
 	}
 	
-    if(image->base_md[0].sem != NBsem)
+    if(image->md[0].sem != NBsem)
     {
         // Close existing semaphores ...
         daoInfo("Closing semaphore\n");
-        for(s=0; s < image->base_md[0].sem; s++)
+        for(s=0; s < image->md[0].sem; s++)
         {
             CloseHandle(image->semptr[s]);
         }
-        image->base_md[0].sem = 0;
+        image->md[0].sem = 0;
 
         daoInfo("Done\n");
         //free(image->semptr);
         image->semptr = NULL;
     }
 #else
-    if(image->base_md[0].sem != NBsem)
+    if(image->md[0].sem != NBsem)
     {
         // Close existing semaphores ...
         daoInfo("Closing semaphore\n");
-        for(s=0; s < image->base_md[0].sem; s++)
+        for(s=0; s < image->md[0].sem; s++)
         {
             sem_close(image->semptr[s]);
         }
-        image->base_md[0].sem = 0;
+        image->md[0].sem = 0;
 
         daoInfo("Remove associated files\n");
 		// ... and remove associated files
@@ -1216,18 +1167,18 @@ int_fast8_t daoImageCreateSem(IMAGE *image, long NBsem)
 #endif
 
 
-    if(image->base_md[0].sem == 0)
+    if(image->md[0].sem == 0)
     {
         if(image->semptr!=NULL)
             free(image->semptr);
 
-        image->base_md[0].sem = (uint16_t)NBsem;
-        daoInfo("malloc semptr %d entries\n", image->base_md[0].sem);
+        image->md[0].sem = (uint16_t)NBsem;
+        daoInfo("malloc semptr %d entries\n", image->md[0].sem);
 
 #ifdef _WIN32
-        image->semptr = (HANDLE*) malloc(sizeof(HANDLE*)*image->base_md[0].sem);
+        image->semptr = (HANDLE*) malloc(sizeof(HANDLE*)*image->md[0].sem);
 #else
-        image->semptr = (sem_t**) malloc(sizeof(sem_t**)*image->base_md[0].sem);
+        image->semptr = (sem_t**) malloc(sizeof(sem_t**)*image->md[0].sem);
 #endif
         
         for(s=0; s<NBsem; s++)
@@ -1522,13 +1473,13 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         }
 #endif
 	
-        image->base_md = (IMAGE_METADATA*) map;
-        image->base_md[0].fifo_size = fifo_size;
+        image->md = (IMAGE_METADATA*) map;
+        image->md[0].fifo_size = fifo_size;
 
         for (uint32_t fifo_idx = 0; fifo_idx < fifo_size; ++fifo_idx)
         {
-            image->base_md[fifo_idx].shared = 1;
-            image->base_md[fifo_idx].sem = 0;
+            image->md[fifo_idx].shared = 1;
+            image->md[fifo_idx].sem = 0;
         }
 
         free(nameCopy);
@@ -1539,12 +1490,12 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
     }
     else
     {
-        image->base_md = (IMAGE_METADATA*) malloc(sizeof(IMAGE_METADATA) * fifo_size);
-        image->base_md[0].fifo_size = fifo_size;
+        image->md = (IMAGE_METADATA*) malloc(sizeof(IMAGE_METADATA) * fifo_size);
+        image->md[0].fifo_size = fifo_size;
 
         for (uint32_t fifo_idx = 0; fifo_idx < fifo_size; ++fifo_idx)
         {
-            image->base_md[fifo_idx].shared = 0;
+            image->md[fifo_idx].shared = 0;
         }
 
         if(NBkw>0)
@@ -1560,16 +1511,16 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
     strcpy(image->name, name); // local name
     for (uint32_t fifo_idx = 0; fifo_idx < fifo_size; ++fifo_idx)
     {
-        image->base_md[fifo_idx].atype = atype;
-        image->base_md[fifo_idx].naxis = (uint8_t)naxis;
+        image->md[fifo_idx].atype = atype;
+        image->md[fifo_idx].naxis = (uint8_t)naxis;
 
-        strcpy(image->base_md[fifo_idx].name, name);
+        strcpy(image->md[fifo_idx].name, name);
 
         for(i=0; i<naxis; i++)
         {
-            image->base_md[fifo_idx].size[i] = size[i];
+            image->md[fifo_idx].size[i] = size[i];
         }
-        image->base_md[fifo_idx].NBkw = NBkw;
+        image->md[fifo_idx].NBkw = NBkw;
     }
 
 
@@ -1579,18 +1530,18 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
 			mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
-            image->base_array.UI8 = (uint8_t*) (mapv);
-            memset(image->base_array.UI8, '\0', nelement*sizeof(uint8_t));
+            image->array.UI8 = (uint8_t*) (mapv);
+            memset(image->array.UI8, '\0', nelement*sizeof(uint8_t));
             mapv += sizeof(uint8_t)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
 		}
         else
         {
-            image->base_array.UI8 = (uint8_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint8_t));
+            image->array.UI8 = (uint8_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint8_t));
         }
 
 
-        if(image->base_array.UI8 == NULL)
+        if(image->array.UI8 == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1613,16 +1564,16 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
 			mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
-            image->base_array.SI8 = (int8_t*) (mapv);
-            memset(image->base_array.SI8, '\0', nelement*sizeof(int8_t));
+            image->array.SI8 = (int8_t*) (mapv);
+            memset(image->array.SI8, '\0', nelement*sizeof(int8_t));
             mapv += sizeof(int8_t)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
 		}
         else
-            image->base_array.SI8 = (int8_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int8_t));
+            image->array.SI8 = (int8_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int8_t));
 
 
-        if(image->base_array.SI8 == NULL)
+        if(image->array.SI8 == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1647,17 +1598,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
             mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
-            image->base_array.UI16 = (uint16_t*) (mapv);
-            memset(image->base_array.UI16, '\0', nelement*sizeof(uint16_t));
+            image->array.UI16 = (uint16_t*) (mapv);
+            memset(image->array.UI16, '\0', nelement*sizeof(uint16_t));
             mapv += sizeof(uint16_t)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->base_array.UI16 = (uint16_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint16_t));
+            image->array.UI16 = (uint16_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint16_t));
         }
 
-        if(image->base_array.UI16 == NULL)
+        if(image->array.UI16 == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1680,17 +1631,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
             mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
-            image->base_array.SI16 = (int16_t*) (mapv);
-            memset(image->base_array.SI16, '\0', nelement*sizeof(int16_t));
+            image->array.SI16 = (int16_t*) (mapv);
+            memset(image->array.SI16, '\0', nelement*sizeof(int16_t));
             mapv += sizeof(int16_t)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->base_array.SI16 = (int16_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int16_t));
+            image->array.SI16 = (int16_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int16_t));
         }
 
-        if(image->base_array.SI16 == NULL)
+        if(image->array.SI16 == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1716,17 +1667,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
 			mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
-            image->base_array.UI32 = (uint32_t*) (mapv);
-            memset(image->base_array.UI32, '\0', nelement*sizeof(uint32_t));
+            image->array.UI32 = (uint32_t*) (mapv);
+            memset(image->array.UI32, '\0', nelement*sizeof(uint32_t));
             mapv += sizeof(uint32_t)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->base_array.UI32 = (uint32_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint32_t));
+            image->array.UI32 = (uint32_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint32_t));
         }
 
-        if(image->base_array.UI32 == NULL)
+        if(image->array.UI32 == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1753,17 +1704,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
 			mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
-            image->base_array.SI32 = (int32_t*) (mapv);
-            memset(image->base_array.SI32, '\0', nelement*sizeof(int32_t));
+            image->array.SI32 = (int32_t*) (mapv);
+            memset(image->array.SI32, '\0', nelement*sizeof(int32_t));
             mapv += sizeof(int32_t)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->base_array.SI32 = (int32_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int32_t));
+            image->array.SI32 = (int32_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int32_t));
         }
 
-        if(image->base_array.SI32 == NULL)
+        if(image->array.SI32 == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1790,17 +1741,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
 			mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
-            image->base_array.UI64 = (uint64_t*) (mapv);
-            memset(image->base_array.UI64, '\0', nelement*sizeof(uint64_t));
+            image->array.UI64 = (uint64_t*) (mapv);
+            memset(image->array.UI64, '\0', nelement*sizeof(uint64_t));
             mapv += sizeof(uint64_t)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->base_array.UI64 = (uint64_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint64_t));
+            image->array.UI64 = (uint64_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(uint64_t));
         }
 
-        if(image->base_array.SI64 == NULL)
+        if(image->array.SI64 == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1825,17 +1776,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
 			mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
-            image->base_array.SI64 = (int64_t*) (mapv);
-            memset(image->base_array.SI64, '\0', nelement*sizeof(int64_t));
+            image->array.SI64 = (int64_t*) (mapv);
+            memset(image->array.SI64, '\0', nelement*sizeof(int64_t));
             mapv += sizeof(int64_t)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->base_array.SI64 = (int64_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int64_t));
+            image->array.SI64 = (int64_t*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(int64_t));
         }
 
-        if(image->base_array.SI64 == NULL)
+        if(image->array.SI64 == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1861,17 +1812,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
             mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
-            image->base_array.F = (float*) (mapv);
-            memset(image->base_array.F, '\0', nelement*sizeof(float));
+            image->array.F = (float*) (mapv);
+            memset(image->array.F, '\0', nelement*sizeof(float));
             mapv += sizeof(float)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->base_array.F = (float*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(float));
+            image->array.F = (float*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(float));
         }
 
-        if(image->base_array.F == NULL)
+        if(image->array.F == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1896,17 +1847,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
 			mapv = (char*) map;
 			mapv += sizeof(IMAGE_METADATA) * fifo_size;
-			image->base_array.D = (double*) (mapv);
-            memset(image->base_array.D, '\0', nelement*sizeof(double));
+			image->array.D = (double*) (mapv);
+            memset(image->array.D, '\0', nelement*sizeof(double));
             mapv += sizeof(double)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->base_array.D = (double*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(double));
+            image->array.D = (double*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(double));
         }
   
-        if(image->base_array.D == NULL)
+        if(image->array.D == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1931,17 +1882,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
 			mapv = (char*) map;
 			mapv += sizeof(IMAGE_METADATA) * fifo_size;
-			image->base_array.CF = (complex_float*) (mapv);			
-            memset(image->base_array.CF, '\0', nelement*sizeof(complex_float));
+			image->array.CF = (complex_float*) (mapv);			
+            memset(image->array.CF, '\0', nelement*sizeof(complex_float));
             mapv += sizeof(complex_float)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->base_array.CF = (complex_float*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(complex_float));
+            image->array.CF = (complex_float*) calloc ((size_t) nelement * (size_t) fifo_size, sizeof(complex_float));
         }
 
-        if(image->base_array.CF == NULL)
+        if(image->array.CF == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1966,17 +1917,17 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         {
 			mapv = (char*) map;
 			mapv += sizeof(IMAGE_METADATA) * fifo_size;
-			image->base_array.CD = (complex_double*) (mapv);			
-            memset(image->base_array.CD, '\0', nelement*sizeof(complex_double));
+			image->array.CD = (complex_double*) (mapv);			
+            memset(image->array.CD, '\0', nelement*sizeof(complex_double));
             mapv += sizeof(complex_double)*nelement;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
         {
-            image->base_array.CD = (complex_double*) calloc ((size_t) nelement * (size_t) fifo_size,sizeof(complex_double));
+            image->array.CD = (complex_double*) calloc ((size_t) nelement * (size_t) fifo_size,sizeof(complex_double));
         }
 
-        if(image->base_array.CD == NULL)
+        if(image->array.CD == NULL)
         {
             daoError("memory allocation failed\n");
             fprintf(stderr,"%c[%d;%dm", (char) 27, 1, 31);
@@ -1999,12 +1950,12 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
 
     for (uint32_t fifo_idx = 0; fifo_idx < fifo_size; ++fifo_idx)
     {
-        image->base_md[fifo_idx].last_access = 1.0*timenow.tv_sec + 0.000000001*timenow.tv_nsec;
-        image->base_md[fifo_idx].creation_time = image->base_md[0].last_access;
-        image->base_md[fifo_idx].write = 0;
-        image->base_md[fifo_idx].cnt0 = 0;
-        image->base_md[fifo_idx].cnt1 = 0;
-        image->base_md[fifo_idx].nelement = nelement;
+        image->md[fifo_idx].last_access = 1.0*timenow.tv_sec + 0.000000001*timenow.tv_nsec;
+        image->md[fifo_idx].creation_time = image->md[0].last_access;
+        image->md[fifo_idx].write = 0;
+        image->md[fifo_idx].cnt0 = 0;
+        image->md[fifo_idx].cnt1 = 0;
+        image->md[fifo_idx].nelement = nelement;
     }
 
     if(shared==1)
@@ -2014,40 +1965,34 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
         daoInfo("Semaphores created\n");
 
 #ifdef __APPLE__
-        for (int i = 0; i < image->base_md[0].sem; i++)
+        for (int i = 0; i < image->md[0].sem; i++)
         {
             while (sem_trywait(image->semptr[i]) == 0) 
             {
                 // Draining kernel-level semaphore
             }
-            atomic_store(&image->base_md[0].semCounter[i], 0);
+            atomic_store(&image->md[0].semCounter[i], 0);
         }
-        atomic_store(&image->base_md[0].semLogCounter, 0);
+        atomic_store(&image->md[0].semLogCounter, 0);
 #endif
     }
     else
     {
-		image->base_md[0].sem = 0; // no semaphores
+		image->md[0].sem = 0; // no semaphores
     }
 
     // set fifo last written position
-    image->base_md[0].fifo_size = fifo_size;
-    image->base_md[0].fifo_last_written = fifo_size - 1;
+    image->md[0].fifo_size = fifo_size;
+    image->md[0].fifo_last_written = fifo_size - 1;
 
     // set up FIFO tail
 
-    uint32_t tail_idx;
-    uint64_t tail_cnt0;
-    daoShmResetTail(image, &tail_idx, &tail_cnt0);
-
-    // Set up array pointer for writing the one after our current position - this step is crucial for SHM writers, and
-    // has no effect on SHM reading, as long as the application always calls wait before the update
-
-    tail_idx = ((tail_idx + 1) >= image->base_md[0].fifo_size) ? 0 : tail_idx + 1;
-    IMAGE_MD_PTR_UPDATE_IDX(image, tail_idx);
+    uint32_t tmp32;
+    uint64_t tmp64;
+    daoShmResetTail(image, &tmp32, &tmp64);
 
     // initialize keywords
-    for(kw=0; kw<image->base_md[0].NBkw; kw++)
+    for(kw=0; kw<image->md[0].NBkw; kw++)
     {
         image->kw[kw].type = 'N';
     }
@@ -2062,12 +2007,12 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
     uint64_t fifo_reading_offset[DAO_MAX_COMBINE_CHANNELS];
 
     // Get output image writing position
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
 
     uint32_t last_written = vol_md[0].fifo_last_written;
-    uint32_t writing_idx = (last_written + 1) % (image->base_md[0].fifo_size);
+    uint32_t writing_idx = (last_written + 1) % (image->md[0].fifo_size);
 
-    uint64_t fifo_writing_offset = image->base_md[0].nelement * (uint64_t)writing_idx;
+    uint64_t fifo_writing_offset = image->md[0].nelement * (uint64_t)writing_idx;
 
     vol_md[writing_idx].write = 1;
 
@@ -2091,153 +2036,153 @@ int_fast8_t daoShmCombineShm2Shm(IMAGE **imageCube, IMAGE *image, int nbChannel,
     }
     
     // check type and use proper array
-    if (image->base_md[0].atype == _DATATYPE_UINT8)
+    if (image->md[0].atype == _DATATYPE_UINT8)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].base_array.UI8[fifo_writing_offset + pp] = 0;
+            image[0].array.UI8[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].base_array.UI8[fifo_writing_offset + pp]
-                    += imageCube[k][0].base_array.UI8[fifo_reading_offset[k] + pp];
+                image[0].array.UI8[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.UI8[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->base_md[0].atype == _DATATYPE_INT8)
+    else if (image->md[0].atype == _DATATYPE_INT8)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].base_array.SI8[fifo_writing_offset + pp] = 0;
+            image[0].array.SI8[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].base_array.SI8[fifo_writing_offset + pp]
-                    += imageCube[k][0].base_array.SI8[fifo_reading_offset[k] + pp];
+                image[0].array.SI8[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.SI8[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->base_md[0].atype == _DATATYPE_UINT16)
+    else if (image->md[0].atype == _DATATYPE_UINT16)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].base_array.UI16[fifo_writing_offset + pp] = 0;
+            image[0].array.UI16[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].base_array.UI16[fifo_writing_offset + pp]
-                    += imageCube[k][0].base_array.UI16[fifo_reading_offset[k] + pp];
+                image[0].array.UI16[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.UI16[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->base_md[0].atype == _DATATYPE_INT16)
+    else if (image->md[0].atype == _DATATYPE_INT16)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].base_array.SI16[fifo_writing_offset + pp] = 0;
+            image[0].array.SI16[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].base_array.SI16[fifo_writing_offset + pp]
-                    += imageCube[k][0].base_array.SI16[fifo_reading_offset[k] + pp];
+                image[0].array.SI16[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.SI16[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->base_md[0].atype == _DATATYPE_UINT32)
+    else if (image->md[0].atype == _DATATYPE_UINT32)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].base_array.UI32[fifo_writing_offset + pp] = 0;
+            image[0].array.UI32[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].base_array.UI32[fifo_writing_offset + pp]
-                    += imageCube[k][0].base_array.UI32[fifo_reading_offset[k] + pp];
+                image[0].array.UI32[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.UI32[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->base_md[0].atype == _DATATYPE_INT32)
+    else if (image->md[0].atype == _DATATYPE_INT32)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].base_array.SI32[fifo_writing_offset + pp] = 0;
+            image[0].array.SI32[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].base_array.SI32[fifo_writing_offset + pp]
-                    += imageCube[k][0].base_array.SI32[fifo_reading_offset[k] + pp];
+                image[0].array.SI32[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.SI32[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->base_md[0].atype == _DATATYPE_UINT64)
+    else if (image->md[0].atype == _DATATYPE_UINT64)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].base_array.UI64[fifo_writing_offset + pp] = 0;
+            image[0].array.UI64[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].base_array.UI64[fifo_writing_offset + pp]
-                    += imageCube[k][0].base_array.UI64[fifo_reading_offset[k] + pp];
+                image[0].array.UI64[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.UI64[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->base_md[0].atype == _DATATYPE_INT64)
+    else if (image->md[0].atype == _DATATYPE_INT64)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].base_array.SI64[fifo_writing_offset + pp] = 0;
+            image[0].array.SI64[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].base_array.SI64[fifo_writing_offset + pp]
-                    += imageCube[k][0].base_array.SI64[fifo_reading_offset[k] + pp];
+                image[0].array.SI64[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.SI64[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->base_md[0].atype == _DATATYPE_FLOAT)
+    else if (image->md[0].atype == _DATATYPE_FLOAT)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].base_array.F[fifo_writing_offset + pp] = 0;
+            image[0].array.F[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].base_array.F[fifo_writing_offset + pp]
-                    += imageCube[k][0].base_array.F[fifo_reading_offset[k] + pp];
+                image[0].array.F[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.F[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->base_md[0].atype == _DATATYPE_DOUBLE)
+    else if (image->md[0].atype == _DATATYPE_DOUBLE)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].base_array.D[fifo_writing_offset + pp] = 0;
+            image[0].array.D[fifo_writing_offset + pp] = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].base_array.D[fifo_writing_offset + pp]
-                    += imageCube[k][0].base_array.D[fifo_reading_offset[k] + pp];
+                image[0].array.D[fifo_writing_offset + pp]
+                    += imageCube[k][0].array.D[fifo_reading_offset[k] + pp];
             }
         }
     }
-    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_FLOAT)
+    else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].base_array.CF[fifo_writing_offset + pp].re = 0;
-            image[0].base_array.CF[fifo_writing_offset + pp].im = 0;
+            image[0].array.CF[fifo_writing_offset + pp].re = 0;
+            image[0].array.CF[fifo_writing_offset + pp].im = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].base_array.CF[fifo_writing_offset + pp].re
-                    += imageCube[k][0].base_array.CF[fifo_reading_offset[k] + pp].re;
-                image[0].base_array.CF[fifo_writing_offset + pp].im
-                    += imageCube[k][0].base_array.CF[fifo_reading_offset[k] + pp].im;
+                image[0].array.CF[fifo_writing_offset + pp].re
+                    += imageCube[k][0].array.CF[fifo_reading_offset[k] + pp].re;
+                image[0].array.CF[fifo_writing_offset + pp].im
+                    += imageCube[k][0].array.CF[fifo_reading_offset[k] + pp].im;
             }
         }
     }
-        else if (image->base_md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
+        else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
     {
         for (pp=0; pp<nbVal; pp++)
         {   
-            image[0].base_array.CD[fifo_writing_offset + pp].re = 0;
-            image[0].base_array.CD[fifo_writing_offset + pp].im = 0;
+            image[0].array.CD[fifo_writing_offset + pp].re = 0;
+            image[0].array.CD[fifo_writing_offset + pp].im = 0;
             for(k=0;k<nbChannel;k++) 
             {
-                image[0].base_array.CD[fifo_writing_offset + pp].re
-                    += imageCube[k][0].base_array.CD[fifo_reading_offset[k] + pp].re;
-                image[0].base_array.CD[fifo_writing_offset + pp].im
-                    += imageCube[k][0].base_array.CD[fifo_reading_offset[k] + pp].im;
+                image[0].array.CD[fifo_writing_offset + pp].re
+                    += imageCube[k][0].array.CD[fifo_reading_offset[k] + pp].re;
+                image[0].array.CD[fifo_writing_offset + pp].im
+                    += imageCube[k][0].array.CD[fifo_reading_offset[k] + pp].im;
             }
         }
     }
@@ -2277,10 +2222,10 @@ int_fast8_t daoShmWaitForSemaphore(IMAGE *image, int32_t semNb)
     if (sem_wait(image->semptr[semNb]) == 0) 
     {
         // Safely decrement the counter, but only if > 0
-        unsigned int val = atomic_load(&image->base_md[0].semCounter[semNb]);
+        unsigned int val = atomic_load(&image->md[0].semCounter[semNb]);
         while (val > 0)
         {
-            if (atomic_compare_exchange_weak(&image->base_md[0].semCounter[semNb], &val, val - 1))
+            if (atomic_compare_exchange_weak(&image->md[0].semCounter[semNb], &val, val - 1))
                 break;
             // If CAS fails, val is updated, loop again
         }
@@ -2293,12 +2238,6 @@ int_fast8_t daoShmWaitForSemaphore(IMAGE *image, int32_t semNb)
 #else
     sem_wait(image->semptr[semNb]);
 #endif
-
-    // Update the current array pointer
-    IMAGE_PTR_UPDATE(image->base_md[0].atype, image->array, image->base_array,
-        image->base_md[0].fifo_last_written, image->base_md[0].nelement);
-
-    IMAGE_MD_PTR_UPDATE_IDX(image, image->base_md[0].fifo_last_written);
 
     return DAO_SUCCESS;
 }
@@ -2344,19 +2283,12 @@ int_fast8_t daoShmWaitForSemaphoreTimeout(IMAGE *image, int32_t semNb, const str
 
     while (now_ns < end_ns)
     {
-        unsigned int val = atomic_load(&image->base_md[0].semCounter[semNb]);
+        unsigned int val = atomic_load(&image->md[0].semCounter[semNb]);
         if (val > 0)
         {
             if (sem_wait(image->semptr[semNb]) == 0)
             {
-                atomic_fetch_sub(&image->base_md[0].semCounter[semNb], 1);
-
-                // Update the current array pointer
-                IMAGE_PTR_UPDATE(image->base_md[0].atype, image->array, image->base_array,
-                    image->base_md[0].fifo_last_written, image->base_md[0].nelement);
-
-                IMAGE_MD_PTR_UPDATE_IDX(image, image->base_md[0].fifo_last_written);
-
+                atomic_fetch_sub(&image->md[0].semCounter[semNb], 1);
                 return DAO_SUCCESS;
             }
             else
@@ -2382,12 +2314,6 @@ int_fast8_t daoShmWaitForSemaphoreTimeout(IMAGE *image, int32_t semNb, const str
     }
 #endif
 
-    // Update the current array pointer
-    IMAGE_PTR_UPDATE(image->base_md[0].atype, image->array, image->base_array,
-        image->base_md[0].fifo_last_written, image->base_md[0].nelement);
-
-    IMAGE_MD_PTR_UPDATE_IDX(image, image->base_md[0].fifo_last_written);
-
     return DAO_SUCCESS;
 }
 
@@ -2400,7 +2326,7 @@ int_fast8_t daoShmWaitForSemaphoreTimeout(IMAGE *image, int32_t semNb, const str
 int_fast8_t daoShmWaitForCounter(IMAGE *image)
 {
     daoTrace("\n");
-    volatile IMAGE_METADATA *md = (volatile IMAGE_METADATA *)image->base_md;
+    volatile IMAGE_METADATA *md = (volatile IMAGE_METADATA *)image->md;
 
     if (md->fifo_size == 1) // Spin on our only cnt0 for 1-deep images
     {
@@ -2411,7 +2337,7 @@ int_fast8_t daoShmWaitForCounter(IMAGE *image)
             // Spin
         }
     #else
-        uint_fast64_t counter = image->base_md[0].cnt0;
+        uint_fast64_t counter = image->md[0].cnt0;
         struct timespec req, rem;
         req.tv_sec = 0;          // Seconds
         req.tv_nsec = 0; // Nanoseconds
@@ -2449,16 +2375,10 @@ int_fast8_t daoShmWaitForCounter(IMAGE *image)
                 return DAO_ERROR;
             }
         }
-        #endif
-
-        // Update the current array pointer
-        IMAGE_PTR_UPDATE(image->base_md[0].atype, image->array, image->base_array,
-            fifo_position, image->base_md[0].nelement);
-
-        IMAGE_MD_PTR_UPDATE_IDX(image, fifo_position);
-
+    #endif
         return DAO_SUCCESS;
     }
+
 }
 
 /**
@@ -2476,7 +2396,7 @@ int_fast8_t daoShmWaitForTargetCounter(IMAGE *image, uint64_t targetCnt0)
     req.tv_sec = 0;          // Seconds
     req.tv_nsec = 0; // Nanoseconds
 
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
 
     if (vol_md->fifo_size == 1) // Spin on our only cnt0 for 1-deep images
     {
@@ -2509,12 +2429,6 @@ int_fast8_t daoShmWaitForTargetCounter(IMAGE *image, uint64_t targetCnt0)
         }
     }
 
-    // Update the current array pointer
-    IMAGE_PTR_UPDATE(image->base_md[0].atype, image->array, image->base_array,
-        image->base_md[0].fifo_last_written, image->base_md[0].nelement);
-
-    IMAGE_MD_PTR_UPDATE_IDX(image, image->base_md[0].fifo_last_written);
-
     return DAO_SUCCESS;
 }
 
@@ -2528,9 +2442,9 @@ uint_fast64_t daoShmGetCounter(IMAGE *image)
 {
     daoTrace("\n");
 
-    uint32_t fifo_last_written = image->base_md[0].fifo_last_written;
+    uint32_t fifo_last_written = image->md[0].fifo_last_written;
 
-    return image->base_md[fifo_last_written].cnt0;
+    return image->md[fifo_last_written].cnt0;
 }
 
 /**
@@ -2555,7 +2469,7 @@ int_fast8_t daoShmGetNextSegment(IMAGE *image, void** segment_ptr, uint32_t* seg
     int_fast8_t return_val = DAO_SUCCESS;
 
     volatile IMAGE *vol_image = (volatile IMAGE *)image;
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
 
     uint32_t last_read_idx  = vol_image->fifo_last_read;
     uint64_t last_read_cnt0 = vol_image->fifo_last_read_cnt0;
@@ -2578,41 +2492,37 @@ int_fast8_t daoShmGetNextSegment(IMAGE *image, void** segment_ptr, uint32_t* seg
     }
 
     // Set the segment pointer and index
-    if (image->base_md[0].atype == _DATATYPE_UINT8)
-        *segment_ptr = &(image->base_array.UI8[next_segment_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_INT8)
-        *segment_ptr = &(image->base_array.SI8[next_segment_idx * image->base_md[0].nelement]);      
-    else if (image->base_md[0].atype == _DATATYPE_UINT16)
-        *segment_ptr = &(image->base_array.UI16[next_segment_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_INT16)
-        *segment_ptr = &(image->base_array.SI16[next_segment_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_INT32)
-        *segment_ptr = &(image->base_array.UI32[next_segment_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_UINT32)
-        *segment_ptr = &(image->base_array.SI32[next_segment_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_UINT64)
-        *segment_ptr = &(image->base_array.UI64[next_segment_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_INT64)
-        *segment_ptr = &(image->base_array.SI64[next_segment_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_FLOAT)
-        *segment_ptr = &(image->base_array.F[next_segment_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_DOUBLE)
-        *segment_ptr = &(image->base_array.D[next_segment_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_FLOAT)
-        *segment_ptr = &(image->base_array.CF[next_segment_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
-        *segment_ptr = &(image->base_array.CD[next_segment_idx * image->base_md[0].nelement]);
+    if (image->md[0].atype == _DATATYPE_UINT8)
+        *segment_ptr = &(image->array.UI8[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT8)
+        *segment_ptr = &(image->array.SI8[next_segment_idx * image->md[0].nelement]);      
+    else if (image->md[0].atype == _DATATYPE_UINT16)
+        *segment_ptr = &(image->array.UI16[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT16)
+        *segment_ptr = &(image->array.SI16[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT32)
+        *segment_ptr = &(image->array.UI32[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_UINT32)
+        *segment_ptr = &(image->array.SI32[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_UINT64)
+        *segment_ptr = &(image->array.UI64[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT64)
+        *segment_ptr = &(image->array.SI64[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_FLOAT)
+        *segment_ptr = &(image->array.F[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_DOUBLE)
+        *segment_ptr = &(image->array.D[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
+        *segment_ptr = &(image->array.CF[next_segment_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
+        *segment_ptr = &(image->array.CD[next_segment_idx * image->md[0].nelement]);
 
     *segment_idx = next_segment_idx;
     *segment_cnt0 = next_segment_cnt0;
 
     // Update the bookkeeping variables for this FIFO tail our IMAGE struct
-    image->fifo_last_read = next_segment_idx;
-    image->fifo_last_read_cnt0 = next_segment_cnt0;
-
-    IMAGE_PTR_UPDATE_DIRECT(image->array, segment_ptr);
-
-    IMAGE_MD_PTR_UPDATE_IDX(image, next_segment_idx);
+    vol_image->fifo_last_read = next_segment_idx;
+    vol_image->fifo_last_read_cnt0 = next_segment_cnt0;
 
     return return_val;
 }
@@ -2638,36 +2548,32 @@ int_fast8_t daoShmWaitForNextSegment(IMAGE *image)
  */
 int_fast8_t daoShmGetArbitrarySegment(IMAGE *image, void** segment_ptr, uint_fast32_t fifo_idx)
 {
-    uint32_t actual_idx = (uint32_t)(fifo_idx % image->base_md[0].fifo_size);
+    uint32_t actual_idx = (uint32_t)(fifo_idx % image->md[0].fifo_size);
 
-    if (image->base_md[0].atype == _DATATYPE_UINT8)
-        *segment_ptr = &(image->base_array.UI8[actual_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_INT8)
-        *segment_ptr = &(image->base_array.SI8[actual_idx * image->base_md[0].nelement]);      
-    else if (image->base_md[0].atype == _DATATYPE_UINT16)
-        *segment_ptr = &(image->base_array.UI16[actual_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_INT16)
-        *segment_ptr = &(image->base_array.SI16[actual_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_INT32)
-        *segment_ptr = &(image->base_array.UI32[actual_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_UINT32)
-        *segment_ptr = &(image->base_array.SI32[actual_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_UINT64)
-        *segment_ptr = &(image->base_array.UI64[actual_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_INT64)
-        *segment_ptr = &(image->base_array.SI64[actual_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_FLOAT)
-        *segment_ptr = &(image->base_array.F[actual_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_DOUBLE)
-        *segment_ptr = &(image->base_array.D[actual_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_FLOAT)
-        *segment_ptr = &(image->base_array.CF[actual_idx * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
-        *segment_ptr = &(image->base_array.CD[actual_idx * image->base_md[0].nelement]);
-
-    IMAGE_PTR_UPDATE_DIRECT(image->array, segment_ptr);
-
-    IMAGE_MD_PTR_UPDATE_IDX(image, actual_idx);
+    if (image->md[0].atype == _DATATYPE_UINT8)
+        *segment_ptr = &(image->array.UI8[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT8)
+        *segment_ptr = &(image->array.SI8[actual_idx * image->md[0].nelement]);      
+    else if (image->md[0].atype == _DATATYPE_UINT16)
+        *segment_ptr = &(image->array.UI16[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT16)
+        *segment_ptr = &(image->array.SI16[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT32)
+        *segment_ptr = &(image->array.UI32[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_UINT32)
+        *segment_ptr = &(image->array.SI32[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_UINT64)
+        *segment_ptr = &(image->array.UI64[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT64)
+        *segment_ptr = &(image->array.SI64[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_FLOAT)
+        *segment_ptr = &(image->array.F[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_DOUBLE)
+        *segment_ptr = &(image->array.D[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
+        *segment_ptr = &(image->array.CF[actual_idx * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
+        *segment_ptr = &(image->array.CD[actual_idx * image->md[0].nelement]);
 
     return DAO_SUCCESS;
 }
@@ -2682,42 +2588,38 @@ int_fast8_t daoShmGetArbitrarySegment(IMAGE *image, void** segment_ptr, uint_fas
  */
 int_fast8_t daoShmGetNewestSegment(IMAGE *image, void** segment_ptr, uint32_t* segment_idx, uint64_t *segment_cnt0)
 {
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
 
     uint32_t last_written = vol_md[0].fifo_last_written;
     uint64_t cnt0 = vol_md[last_written].cnt0;
 
-    if (image->base_md[0].atype == _DATATYPE_UINT8)
-        *segment_ptr = &(image->base_array.UI8[last_written * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_INT8)
-        *segment_ptr = &(image->base_array.SI8[last_written * image->base_md[0].nelement]);      
-    else if (image->base_md[0].atype == _DATATYPE_UINT16)
-        *segment_ptr = &(image->base_array.UI16[last_written * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_INT16)
-        *segment_ptr = &(image->base_array.SI16[last_written * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_INT32)
-        *segment_ptr = &(image->base_array.UI32[last_written * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_UINT32)
-        *segment_ptr = &(image->base_array.SI32[last_written * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_UINT64)
-        *segment_ptr = &(image->base_array.UI64[last_written * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_INT64)
-        *segment_ptr = &(image->base_array.SI64[last_written * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_FLOAT)
-        *segment_ptr = &(image->base_array.F[last_written * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_DOUBLE)
-        *segment_ptr = &(image->base_array.D[last_written * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_FLOAT)
-        *segment_ptr = &(image->base_array.CF[last_written * image->base_md[0].nelement]);
-    else if (image->base_md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
-        *segment_ptr = &(image->base_array.CD[last_written * image->base_md[0].nelement]);
+    if (image->md[0].atype == _DATATYPE_UINT8)
+        *segment_ptr = &(image->array.UI8[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT8)
+        *segment_ptr = &(image->array.SI8[last_written * image->md[0].nelement]);      
+    else if (image->md[0].atype == _DATATYPE_UINT16)
+        *segment_ptr = &(image->array.UI16[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT16)
+        *segment_ptr = &(image->array.SI16[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT32)
+        *segment_ptr = &(image->array.UI32[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_UINT32)
+        *segment_ptr = &(image->array.SI32[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_UINT64)
+        *segment_ptr = &(image->array.UI64[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_INT64)
+        *segment_ptr = &(image->array.SI64[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_FLOAT)
+        *segment_ptr = &(image->array.F[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_DOUBLE)
+        *segment_ptr = &(image->array.D[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
+        *segment_ptr = &(image->array.CF[last_written * image->md[0].nelement]);
+    else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
+        *segment_ptr = &(image->array.CD[last_written * image->md[0].nelement]);
 
     *segment_idx = last_written;
     *segment_cnt0 = cnt0;
-
-    IMAGE_PTR_UPDATE_DIRECT(image->array, segment_ptr);
-
-    IMAGE_MD_PTR_UPDATE_IDX(image, last_written);
 
     return DAO_SUCCESS;
 }
@@ -2739,7 +2641,7 @@ int_fast8_t daoShmCheckSegmentOverwrite(IMAGE *image)
     int_fast8_t return_val = DAO_SUCCESS;
 
     volatile IMAGE *vol_image = (volatile IMAGE *)image;
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
 
     uint32_t last_read_idx = vol_image->fifo_last_read;
     uint64_t last_read_cnt0 = vol_image->fifo_last_read_cnt0;
@@ -2762,7 +2664,7 @@ int_fast8_t daoShmCheckSegmentOverwrite(IMAGE *image)
  */
 int_fast8_t daoShmResetTail(IMAGE *image, uint32_t* segment_idx, uint64_t *segment_cnt0)
 {
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
 
     uint32_t new_segment_idx = vol_md[0].fifo_last_written;
     uint64_t new_segment_cnt0 = vol_md[new_segment_idx].cnt0;
@@ -2772,12 +2674,6 @@ int_fast8_t daoShmResetTail(IMAGE *image, uint32_t* segment_idx, uint64_t *segme
 
     image->fifo_last_read = new_segment_idx;
     image->fifo_last_read_cnt0 = new_segment_cnt0;
-
-    // Update the current array pointer
-    IMAGE_PTR_UPDATE(image->base_md[0].atype, image->array, image->base_array,
-        new_segment_idx, image->base_md[0].nelement);
-
-    IMAGE_MD_PTR_UPDATE_IDX(image, new_segment_idx);
 
     return DAO_SUCCESS;
 }
@@ -2800,7 +2696,7 @@ int_fast8_t daoShmCloseShm(IMAGE *image)
 
     // Release all semaphores
     if (image->semptr) {
-        for(s = 0; s < image->base_md[0].sem; s++) {
+        for(s = 0; s < image->md[0].sem; s++) {
 #ifdef _WIN32
             if (image->semptr[s]) {
                 CloseHandle(image->semptr[s]);
@@ -2841,12 +2737,12 @@ int_fast8_t daoShmCloseShm(IMAGE *image)
     }
 
     // Unmap memory and close file descriptor if shared
-    if (image->base_md[0].shared) {
+    if (image->md[0].shared) {
 #ifdef _WIN32
         // Windows: Unmap the view and close handles
-        if (image->base_md) {
-            UnmapViewOfFile((LPVOID)image->base_md);
-            image->base_md = NULL;
+        if (image->md) {
+            UnmapViewOfFile((LPVOID)image->md);
+            image->md = NULL;
         }
         if (image->shmfm) {
             CloseHandle(image->shmfm);
@@ -2858,9 +2754,9 @@ int_fast8_t daoShmCloseShm(IMAGE *image)
         }
 #else
         // Unix: Unmap memory and close file descriptor
-        if (image->base_md) {
-            munmap(image->base_md, image->memsize);
-            image->base_md = NULL;
+        if (image->md) {
+            munmap(image->md, image->memsize);
+            image->md = NULL;
         }
         if (image->shmfd > 0) {
             close(image->shmfd);
@@ -2886,7 +2782,7 @@ int_fast8_t daoShmTimestampShm(IMAGE *image)
     struct timespec t;
     clock_gettime(CLOCK_REALTIME, &t);
 
-    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->base_md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
 
     uint32_t fifo_last_written = vol_md[0].fifo_last_written;
     uint32_t fifo_prior_write = (fifo_last_written == 0)
@@ -2913,24 +2809,24 @@ int_fast8_t daoSemPost(IMAGE *image, int32_t semNb)
 #ifdef _WIN32
     ReleaseSemaphore(image->semptr[semNb], 1, NULL);
 #elif defined(__APPLE__)
-    unsigned int oldval = atomic_load(&image->base_md[0].semCounter[semNb]);
+    unsigned int oldval = atomic_load(&image->md[0].semCounter[semNb]);
 
     while (oldval < SEMAPHORE_MAXVAL)
     {
         // Try to increment semCounter atomically
-        if (atomic_compare_exchange_weak(&image->base_md[0].semCounter[semNb], &oldval, oldval + 1))
+        if (atomic_compare_exchange_weak(&image->md[0].semCounter[semNb], &oldval, oldval + 1))
         {
             // Only post if we managed to reserve a "slot" in semCounter
             if (sem_post(image->semptr[semNb]) == 0)
             {
                 daoDebug("Posted sem %d, new semCounter = %u (pid=%d)\n",
-                         semNb, atomic_load(&image->base_md[0].semCounter[semNb]), getpid());
+                         semNb, atomic_load(&image->md[0].semCounter[semNb]), getpid());
                 return DAO_SUCCESS;
             }
             else
             {
                 // Rollback the counter change
-                atomic_fetch_sub(&image->base_md[0].semCounter[semNb], 1);
+                atomic_fetch_sub(&image->md[0].semCounter[semNb], 1);
                 daoError("sem_post failed on sem %d: %s\n", semNb, strerror(errno));
                 return DAO_ERROR;
             }
@@ -2960,7 +2856,7 @@ int_fast8_t daoSemPostAll(IMAGE *image)
 {
     daoTrace("\n");
     int ss;
-    for(ss = 0; ss < image->base_md[0].sem; ss++)
+    for(ss = 0; ss < image->md[0].sem; ss++)
     {
         daoSemPost(image, ss);
     }
@@ -2980,12 +2876,12 @@ int_fast8_t daoSemLogPost(IMAGE *image)
 #ifdef _WIN32
     ReleaseSemaphore(image->semlog, 1, NULL);
 #elif defined(__APPLE__)
-    unsigned int val = atomic_load(&image->base_md[0].semLogCounter);
+    unsigned int val = atomic_load(&image->md[0].semLogCounter);
     if (val < SEMAPHORE_MAXVAL)
     {
         if (sem_post(image->semlog) == 0)
         {
-            atomic_fetch_add(&image->base_md[0].semLogCounter, 1);
+            atomic_fetch_add(&image->md[0].semLogCounter, 1);
         }
         else
         {

--- a/src/c/dao.c
+++ b/src/c/dao.c
@@ -1543,8 +1543,8 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
 			mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
             image->array.UI8 = (uint8_t*) (mapv);
-            memset(image->array.UI8, '\0', nelement*sizeof(uint8_t));
-            mapv += sizeof(uint8_t)*nelement;
+            memset(image->array.UI8, '\0', nelement*sizeof(uint8_t) * fifo_size);
+            mapv += sizeof(uint8_t)*nelement * fifo_size;
             image->kw = (IMAGE_KEYWORD*) (mapv);
 		}
         else
@@ -1577,8 +1577,8 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
 			mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
             image->array.SI8 = (int8_t*) (mapv);
-            memset(image->array.SI8, '\0', nelement*sizeof(int8_t));
-            mapv += sizeof(int8_t)*nelement;
+            memset(image->array.SI8, '\0', nelement*sizeof(int8_t) * fifo_size);
+            mapv += sizeof(int8_t)*nelement * fifo_size;
             image->kw = (IMAGE_KEYWORD*) (mapv);
 		}
         else
@@ -1611,8 +1611,8 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
             mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
             image->array.UI16 = (uint16_t*) (mapv);
-            memset(image->array.UI16, '\0', nelement*sizeof(uint16_t));
-            mapv += sizeof(uint16_t)*nelement;
+            memset(image->array.UI16, '\0', nelement*sizeof(uint16_t) * fifo_size);
+            mapv += sizeof(uint16_t)*nelement * fifo_size;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
@@ -1644,8 +1644,8 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
             mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
             image->array.SI16 = (int16_t*) (mapv);
-            memset(image->array.SI16, '\0', nelement*sizeof(int16_t));
-            mapv += sizeof(int16_t)*nelement;
+            memset(image->array.SI16, '\0', nelement*sizeof(int16_t) * fifo_size);
+            mapv += sizeof(int16_t)*nelement * fifo_size;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
@@ -1680,8 +1680,8 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
 			mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
             image->array.UI32 = (uint32_t*) (mapv);
-            memset(image->array.UI32, '\0', nelement*sizeof(uint32_t));
-            mapv += sizeof(uint32_t)*nelement;
+            memset(image->array.UI32, '\0', nelement*sizeof(uint32_t) * fifo_size);
+            mapv += sizeof(uint32_t)*nelement * fifo_size;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
@@ -1717,8 +1717,8 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
 			mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
             image->array.SI32 = (int32_t*) (mapv);
-            memset(image->array.SI32, '\0', nelement*sizeof(int32_t));
-            mapv += sizeof(int32_t)*nelement;
+            memset(image->array.SI32, '\0', nelement*sizeof(int32_t) * fifo_size);
+            mapv += sizeof(int32_t)*nelement * fifo_size;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
@@ -1754,8 +1754,8 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
 			mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
             image->array.UI64 = (uint64_t*) (mapv);
-            memset(image->array.UI64, '\0', nelement*sizeof(uint64_t));
-            mapv += sizeof(uint64_t)*nelement;
+            memset(image->array.UI64, '\0', nelement*sizeof(uint64_t) * fifo_size);
+            mapv += sizeof(uint64_t)*nelement * fifo_size;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
@@ -1789,8 +1789,8 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
 			mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
             image->array.SI64 = (int64_t*) (mapv);
-            memset(image->array.SI64, '\0', nelement*sizeof(int64_t));
-            mapv += sizeof(int64_t)*nelement;
+            memset(image->array.SI64, '\0', nelement*sizeof(int64_t) * fifo_size);
+            mapv += sizeof(int64_t)*nelement * fifo_size;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
@@ -1825,8 +1825,8 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
             mapv = (char*) map;
             mapv += sizeof(IMAGE_METADATA) * fifo_size;
             image->array.F = (float*) (mapv);
-            memset(image->array.F, '\0', nelement*sizeof(float));
-            mapv += sizeof(float)*nelement;
+            memset(image->array.F, '\0', nelement*sizeof(float) * fifo_size);
+            mapv += sizeof(float)*nelement * fifo_size;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
@@ -1860,8 +1860,8 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
 			mapv = (char*) map;
 			mapv += sizeof(IMAGE_METADATA) * fifo_size;
 			image->array.D = (double*) (mapv);
-            memset(image->array.D, '\0', nelement*sizeof(double));
-            mapv += sizeof(double)*nelement;
+            memset(image->array.D, '\0', nelement*sizeof(double) * fifo_size);
+            mapv += sizeof(double)*nelement * fifo_size;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
@@ -1895,8 +1895,8 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
 			mapv = (char*) map;
 			mapv += sizeof(IMAGE_METADATA) * fifo_size;
 			image->array.CF = (complex_float*) (mapv);			
-            memset(image->array.CF, '\0', nelement*sizeof(complex_float));
-            mapv += sizeof(complex_float)*nelement;
+            memset(image->array.CF, '\0', nelement*sizeof(complex_float) * fifo_size);
+            mapv += sizeof(complex_float)*nelement * fifo_size;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else
@@ -1930,8 +1930,8 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
 			mapv = (char*) map;
 			mapv += sizeof(IMAGE_METADATA) * fifo_size;
 			image->array.CD = (complex_double*) (mapv);			
-            memset(image->array.CD, '\0', nelement*sizeof(complex_double));
-            mapv += sizeof(complex_double)*nelement;
+            memset(image->array.CD, '\0', nelement*sizeof(complex_double) * fifo_size);
+            mapv += sizeof(complex_double)*nelement * fifo_size;
             image->kw = (IMAGE_KEYWORD*) (mapv);
         }
         else

--- a/src/c/dao.c
+++ b/src/c/dao.c
@@ -1985,6 +1985,12 @@ int_fast8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis,
     image->md[0].fifo_size = fifo_size;
     image->md[0].fifo_last_written = fifo_size - 1;
 
+    // set up FIFO tail
+
+    uint32_t tmp32;
+    uint64_t tmp64;
+    daoShmResetTail(image, &tmp32, &tmp64);
+
     // initialize keywords
     for(kw=0; kw<image->md[0].NBkw; kw++)
     {

--- a/src/c/dao.c
+++ b/src/c/dao.c
@@ -2273,28 +2273,57 @@ int_fast8_t daoShmWaitForCounter(IMAGE *image)
     daoTrace("\n");
     volatile IMAGE_METADATA *md = (volatile IMAGE_METADATA *)image->md;
 
-    #ifdef _WIN32
-    volatile uint_fast64_t counter = md->cnt0;
-	while (md->cnt0 <= counter)
-	{
-		// Spin
-	}
-#else
-	uint_fast64_t counter = image->md[0].cnt0;
-    struct timespec req, rem;
-    req.tv_sec = 0;          // Seconds
-    req.tv_nsec = 0; // Nanoseconds
-    while (md->cnt0 <= counter)
+    if (md->fifo_size == 1) // Spin on our only cnt0 for 1-deep images
     {
-        // Spin
-        if (nanosleep(&req, &rem) < 0) 
+    #ifdef _WIN32
+        volatile uint_fast64_t counter = md->cnt0;
+        while (md->cnt0 <= counter)
         {
-            printf("Nanosleep interrupted\n");
-            return DAO_ERROR;
+            // Spin
         }
+    #else
+        uint_fast64_t counter = image->md[0].cnt0;
+        struct timespec req, rem;
+        req.tv_sec = 0;          // Seconds
+        req.tv_nsec = 0; // Nanoseconds
+        while (md->cnt0 <= counter)
+        {
+            // Spin
+            if (nanosleep(&req, &rem) < 0) 
+            {
+                printf("Nanosleep interrupted\n");
+                return DAO_ERROR;
+            }
+        }
+    #endif
+        return DAO_SUCCESS;
     }
-#endif
-    return DAO_SUCCESS;
+    else // Spin on writing position for everything else
+    {
+    #ifdef _WIN32
+        volatile uint32_t fifo_position = md->fifo_last_written;
+        while (md->fifo_last_written == fifo_position)
+        {
+            // Spin
+        }
+    #else
+        uint32_t fifo_position = md->fifo_last_written;
+        struct timespec req, rem;
+        req.tv_sec = 0;          // Seconds
+        req.tv_nsec = 0; // Nanoseconds
+        while (md->fifo_last_written == fifo_position)
+        {
+            // Spin
+            if (nanosleep(&req, &rem) < 0) 
+            {
+                printf("Nanosleep interrupted\n");
+                return DAO_ERROR;
+            }
+        }
+    #endif
+        return DAO_SUCCESS;
+    }
+
 }
 
 /**
@@ -2313,13 +2342,35 @@ int_fast8_t daoShmWaitForTargetCounter(IMAGE *image, uint64_t targetCnt0)
     req.tv_nsec = 0; // Nanoseconds
 
     volatile IMAGE_METADATA *md = (volatile IMAGE_METADATA *)image->md;
-    while (md->cnt0 < targetCnt0)
+
+    if (md->fifo_size == 1) // Spin on our only cnt0 for 1-deep images
     {
-        // Spin
-        if (nanosleep(&req, &rem) < 0) 
+        while (md->cnt0 < targetCnt0)
         {
-            printf("Nanosleep interrupted\n");
-            return DAO_ERROR;
+            // Spin
+            if (nanosleep(&req, &rem) < 0) 
+            {
+                printf("Nanosleep interrupted\n");
+                return DAO_ERROR;
+            }
+        }
+    }
+    else // Keep checking writing position
+    {
+        while (1)
+        {
+            // Check counter of last position
+            uint32_t fifo_last_written = image->md[0].fifo_last_written;
+
+            if (md[fifo_last_written].cnt0 >= targetCnt0)
+                break;
+
+            // Spin
+            if (nanosleep(&req, &rem) < 0) 
+            {
+                printf("Nanosleep interrupted\n");
+                return DAO_ERROR;
+            }
         }
     }
 
@@ -2335,7 +2386,10 @@ int_fast8_t daoShmWaitForTargetCounter(IMAGE *image, uint64_t targetCnt0)
 uint_fast64_t daoShmGetCounter(IMAGE *image)
 {
     daoTrace("\n");
-    return image->md[0].cnt0;
+
+    uint32_t fifo_last_written = image->md[0].fifo_last_written;
+
+    return image->md[fifo_last_written].cnt0;
 }
 
 /**

--- a/src/c/dao.c
+++ b/src/c/dao.c
@@ -827,6 +827,12 @@ int_fast8_t daoShmShm2Img(const char *name, IMAGE *image)
         }
 #endif
         free(nameCopy);
+
+        // Set up FIFO tail
+
+        uint32_t tmp32;
+        uint64_t tmp64;
+        daoShmResetTail(image, &tmp32, &tmp64);
     }
     return(rval);
 }
@@ -2341,11 +2347,11 @@ int_fast8_t daoShmWaitForTargetCounter(IMAGE *image, uint64_t targetCnt0)
     req.tv_sec = 0;          // Seconds
     req.tv_nsec = 0; // Nanoseconds
 
-    volatile IMAGE_METADATA *md = (volatile IMAGE_METADATA *)image->md;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
 
-    if (md->fifo_size == 1) // Spin on our only cnt0 for 1-deep images
+    if (vol_md->fifo_size == 1) // Spin on our only cnt0 for 1-deep images
     {
-        while (md->cnt0 < targetCnt0)
+        while (vol_md->cnt0 < targetCnt0)
         {
             // Spin
             if (nanosleep(&req, &rem) < 0) 
@@ -2360,9 +2366,9 @@ int_fast8_t daoShmWaitForTargetCounter(IMAGE *image, uint64_t targetCnt0)
         while (1)
         {
             // Check counter of last position
-            uint32_t fifo_last_written = image->md[0].fifo_last_written;
+            uint32_t fifo_last_written = vol_md[0].fifo_last_written;
 
-            if (md[fifo_last_written].cnt0 >= targetCnt0)
+            if (vol_md[fifo_last_written].cnt0 >= targetCnt0)
                 break;
 
             // Spin
@@ -2396,18 +2402,18 @@ uint_fast64_t daoShmGetCounter(IMAGE *image)
  * @brief Get the next segment of this shared memory, or the newest if our tail position has been lapped.
  * 
  * @param image 
- * @param segmentPtr Pointer to start of the next segment's array
- * @param segmentIdx Numerical index of the next segment
+ * @param segment_ptr Pointer to start of the next segment's array
+ * @param segment_idx Numerical index of the next segment
  * @return int_fast8_t DAO_OVERWRITE if tail has been lapped, otherwise DAO_SUCCESS
  */
-int_fast8_t daoShmGetNextSegment(IMAGE *image, void** segmentPtr, uint32_t* segmentIdx)
+int_fast8_t daoShmGetNextSegment(IMAGE *image, void** segment_ptr, uint32_t* segment_idx, uint64_t *segment_cnt0)
 {
     // Pseudocode
     // 1. get last_read_idx from IMAGE
     // 3. increment last_read_idx next segment
     // 4. get cnt0 from next segment
     // 5. if next segment_cnt0 != last_read_cnt0 + 1, we have been lapped, so reset tail
-    // 6. set segmentPtr and segmentIdx with last_read_idx
+    // 6. set segment_ptr and segment_idx with last_read_idx
     // 2. set to last_read_idx 
     // 7. return DAO_OVERWRITE if lapped, DAO_SUCCESS otherwise
 
@@ -2423,6 +2429,12 @@ int_fast8_t daoShmGetNextSegment(IMAGE *image, void** segmentPtr, uint32_t* segm
     uint32_t next_segment_idx = (last_read_idx + 1) % vol_md[0].fifo_size;
     uint64_t next_segment_cnt0 = last_read_cnt0 + 1;
 
+    // Return if we haven't got any new data yet
+    if ((last_read_idx == vol_md[0].fifo_last_written) && (last_read_cnt0 == vol_md[last_read_idx].cnt0))
+    {
+        return DAO_NOTREADY;
+    }
+
     if (vol_md[next_segment_idx].cnt0 != next_segment_cnt0)
     { // We have been lapped by the writer. Set our position to the newest segment and signal the overwrite condition
         return_val = DAO_OVERWRITE;
@@ -2432,31 +2444,32 @@ int_fast8_t daoShmGetNextSegment(IMAGE *image, void** segmentPtr, uint32_t* segm
 
     // Set the segment pointer and index
     if (image->md[0].atype == _DATATYPE_UINT8)
-        *segmentPtr = &(image->array.UI8[next_segment_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.UI8[next_segment_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_INT8)
-        *segmentPtr = &(image->array.SI8[next_segment_idx * image->md[0].nelement]);      
+        *segment_ptr = &(image->array.SI8[next_segment_idx * image->md[0].nelement]);      
     else if (image->md[0].atype == _DATATYPE_UINT16)
-        *segmentPtr = &(image->array.UI16[next_segment_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.UI16[next_segment_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_INT16)
-        *segmentPtr = &(image->array.SI16[next_segment_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.SI16[next_segment_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_INT32)
-        *segmentPtr = &(image->array.UI32[next_segment_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.UI32[next_segment_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_UINT32)
-        *segmentPtr = &(image->array.SI32[next_segment_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.SI32[next_segment_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_UINT64)
-        *segmentPtr = &(image->array.UI64[next_segment_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.UI64[next_segment_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_INT64)
-        *segmentPtr = &(image->array.SI64[next_segment_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.SI64[next_segment_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_FLOAT)
-        *segmentPtr = &(image->array.F[next_segment_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.F[next_segment_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_DOUBLE)
-        *segmentPtr = &(image->array.D[next_segment_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.D[next_segment_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
-        *segmentPtr = &(image->array.CF[next_segment_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.CF[next_segment_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
-        *segmentPtr = &(image->array.CD[next_segment_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.CD[next_segment_idx * image->md[0].nelement]);
 
-    *segmentIdx = next_segment_idx;
+    *segment_idx = next_segment_idx;
+    *segment_cnt0 = next_segment_cnt0;
 
     // Update the bookkeeping variables for this FIFO tail our IMAGE struct
     vol_image->fifo_last_read = next_segment_idx;
@@ -2466,41 +2479,52 @@ int_fast8_t daoShmGetNextSegment(IMAGE *image, void** segmentPtr, uint32_t* segm
 }
 
 /**
+ * @brief Wait until the next segment is written to the DAO shared memory.
+ * 
+ * @param image 
+ * @return int_fast8_t
+ */
+int_fast8_t daoShmWaitForNextSegment(IMAGE *image)
+{
+    return daoShmWaitForTargetCounter(image, image->fifo_last_read_cnt0 + 1);
+}
+
+/**
  * @brief Get the specified segment of this shared memory.
  * 
  * @param image 
- * @param segmentPtr Pointer to start of the given segment's array
- * @param segmentIdx Numerical index of the segment to get
+ * @param segment_ptr Pointer to start of the given segment's array
+ * @param segment_idx Numerical index of the segment to get
  * @return int_fast8_t
  */
-int_fast8_t daoShmGetArbitrarySegment(IMAGE *image, void** segmentPtr, uint_fast32_t fifoIdx)
+int_fast8_t daoShmGetArbitrarySegment(IMAGE *image, void** segment_ptr, uint_fast32_t fifo_idx)
 {
-    uint32_t actual_idx = (uint32_t)(fifoIdx % image->md[0].fifo_size);
+    uint32_t actual_idx = (uint32_t)(fifo_idx % image->md[0].fifo_size);
 
     if (image->md[0].atype == _DATATYPE_UINT8)
-        *segmentPtr = &(image->array.UI8[actual_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.UI8[actual_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_INT8)
-        *segmentPtr = &(image->array.SI8[actual_idx * image->md[0].nelement]);      
+        *segment_ptr = &(image->array.SI8[actual_idx * image->md[0].nelement]);      
     else if (image->md[0].atype == _DATATYPE_UINT16)
-        *segmentPtr = &(image->array.UI16[actual_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.UI16[actual_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_INT16)
-        *segmentPtr = &(image->array.SI16[actual_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.SI16[actual_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_INT32)
-        *segmentPtr = &(image->array.UI32[actual_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.UI32[actual_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_UINT32)
-        *segmentPtr = &(image->array.SI32[actual_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.SI32[actual_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_UINT64)
-        *segmentPtr = &(image->array.UI64[actual_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.UI64[actual_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_INT64)
-        *segmentPtr = &(image->array.SI64[actual_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.SI64[actual_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_FLOAT)
-        *segmentPtr = &(image->array.F[actual_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.F[actual_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_DOUBLE)
-        *segmentPtr = &(image->array.D[actual_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.D[actual_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
-        *segmentPtr = &(image->array.CF[actual_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.CF[actual_idx * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
-        *segmentPtr = &(image->array.CD[actual_idx * image->md[0].nelement]);
+        *segment_ptr = &(image->array.CD[actual_idx * image->md[0].nelement]);
 
     return DAO_SUCCESS;
 }
@@ -2509,42 +2533,44 @@ int_fast8_t daoShmGetArbitrarySegment(IMAGE *image, void** segmentPtr, uint_fast
  * @brief Get the segment of this shared memory which was last written to.
  * 
  * @param image 
- * @param segmentPtr Pointer to start of the newest segment's array
- * @param segmentIdx Numerical index of the newest segment
+ * @param segment_ptr Pointer to start of the newest segment's array
+ * @param segment_idx Numerical index of the newest segment
  * @return int_fast8_t
  */
-int_fast8_t daoShmGetNewestSegment(IMAGE *image, void** segmentPtr, uint32_t* segment_idx)
+int_fast8_t daoShmGetNewestSegment(IMAGE *image, void** segment_ptr, uint32_t* segment_idx, uint64_t *segment_cnt0)
 {
     volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
 
     uint32_t last_written = vol_md[0].fifo_last_written;
+    uint64_t cnt0 = vol_md[last_written].cnt0;
 
     if (image->md[0].atype == _DATATYPE_UINT8)
-        *segmentPtr = &(image->array.UI8[last_written * image->md[0].nelement]);
+        *segment_ptr = &(image->array.UI8[last_written * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_INT8)
-        *segmentPtr = &(image->array.SI8[last_written * image->md[0].nelement]);      
+        *segment_ptr = &(image->array.SI8[last_written * image->md[0].nelement]);      
     else if (image->md[0].atype == _DATATYPE_UINT16)
-        *segmentPtr = &(image->array.UI16[last_written * image->md[0].nelement]);
+        *segment_ptr = &(image->array.UI16[last_written * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_INT16)
-        *segmentPtr = &(image->array.SI16[last_written * image->md[0].nelement]);
+        *segment_ptr = &(image->array.SI16[last_written * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_INT32)
-        *segmentPtr = &(image->array.UI32[last_written * image->md[0].nelement]);
+        *segment_ptr = &(image->array.UI32[last_written * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_UINT32)
-        *segmentPtr = &(image->array.SI32[last_written * image->md[0].nelement]);
+        *segment_ptr = &(image->array.SI32[last_written * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_UINT64)
-        *segmentPtr = &(image->array.UI64[last_written * image->md[0].nelement]);
+        *segment_ptr = &(image->array.UI64[last_written * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_INT64)
-        *segmentPtr = &(image->array.SI64[last_written * image->md[0].nelement]);
+        *segment_ptr = &(image->array.SI64[last_written * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_FLOAT)
-        *segmentPtr = &(image->array.F[last_written * image->md[0].nelement]);
+        *segment_ptr = &(image->array.F[last_written * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_DOUBLE)
-        *segmentPtr = &(image->array.D[last_written * image->md[0].nelement]);
+        *segment_ptr = &(image->array.D[last_written * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_COMPLEX_FLOAT)
-        *segmentPtr = &(image->array.CF[last_written * image->md[0].nelement]);
+        *segment_ptr = &(image->array.CF[last_written * image->md[0].nelement]);
     else if (image->md[0].atype == _DATATYPE_COMPLEX_DOUBLE)
-        *segmentPtr = &(image->array.CD[last_written * image->md[0].nelement]);
+        *segment_ptr = &(image->array.CD[last_written * image->md[0].nelement]);
 
     *segment_idx = last_written;
+    *segment_cnt0 = cnt0;
 
     return DAO_SUCCESS;
 }
@@ -2583,17 +2609,22 @@ int_fast8_t daoShmCheckSegmentOverwrite(IMAGE *image)
  * @brief Reset the reading tail on this SHM image struct to the current newest segment.
  * 
  * @param image 
- * @param segmentIdx Index to which the tail was reset
+ * @param segment_idx Segment to which the tail was reset
+ * @param segment_cnt0 Current CNT0 of the segment to which the tail was reset
  * @return int_fast8_t
  */
-int_fast8_t daoShmResetTail(IMAGE *image, uint32_t* segmentIdx)
+int_fast8_t daoShmResetTail(IMAGE *image, uint32_t* segment_idx, uint64_t *segment_cnt0)
 {
     volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
 
     uint32_t new_segment_idx = vol_md[0].fifo_last_written;
+    uint64_t new_segment_cnt0 = vol_md[new_segment_idx].cnt0;
 
-    *segmentIdx = new_segment_idx;
+    *segment_idx = new_segment_idx;
+    *segment_cnt0 = new_segment_cnt0;
+
     image->fifo_last_read = new_segment_idx;
+    image->fifo_last_read_cnt0 = new_segment_cnt0;
 
     return DAO_SUCCESS;
 }
@@ -2702,10 +2733,15 @@ int_fast8_t daoShmTimestampShm(IMAGE *image)
     struct timespec t;
     clock_gettime(CLOCK_REALTIME, &t);
 
-    uint32_t fifo_last_written = image->md[0].fifo_last_written;
+    volatile IMAGE_METADATA *vol_md = (volatile IMAGE_METADATA *)image->md;
 
-    image->md[fifo_last_written].atime.tsfixed.secondlong = ((int64_t)(1e9 * t.tv_sec) + t.tv_nsec);
-    image->md[fifo_last_written].cnt0++;
+    uint32_t fifo_last_written = vol_md[0].fifo_last_written;
+    uint32_t fifo_prior_write = (fifo_last_written == 0)
+                                ? vol_md[0].fifo_size - 1
+                                : fifo_last_written - 1;
+
+    vol_md[fifo_last_written].atime.tsfixed.secondlong = ((int64_t)(1e9 * t.tv_sec) + t.tv_nsec);
+    vol_md[fifo_last_written].cnt0 = vol_md[fifo_prior_write].cnt0 + 1;
 
     return DAO_SUCCESS;
 }

--- a/src/python/daoShm.py
+++ b/src/python/daoShm.py
@@ -309,7 +309,9 @@ if sys.platform == "win32":
             ('semWritePID', ctypes.POINTER(ctypes.c_int32)),
             ('shmfm', ctypes.POINTER(ctypes.c_void_p)),
             ('fifo_last_read', ctypes.c_uint32),
-            ('fifo_last_read_cnt0', ctypes.c_uint64)
+            ('fifo_last_read_cnt0', ctypes.c_uint64),
+            ('base_array', ctypes.c_void_p)
+            ('base_md', ctypes.c_void_p)
         ]
 else:
     # Define the IMAGE structure
@@ -344,7 +346,9 @@ else:
             ('semReadPID', ctypes.POINTER(ctypes.c_int32)),
             ('semWritePID', ctypes.POINTER(ctypes.c_int32)),
             ('fifo_last_read', ctypes.c_uint32),
-            ('fifo_last_read_cnt0', ctypes.c_uint64)
+            ('fifo_last_read_cnt0', ctypes.c_uint64),
+            ('base_array', ctypes.c_void_p),
+            ('base_md', ctypes.c_void_p)
         ]
 
 class shm:
@@ -593,19 +597,19 @@ class shm:
         data = None
         
         if result == self.DAO_SUCCESS or result == self.DAO_OVERWRITE:
-            arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.md.contents.size,\
+            arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.base_md.contents.size,\
                                                         ctypes.POINTER(ctypes.c_uint32)), shape=(3,))
 
             arrayPtr = ctypes.cast(arrayPtr,\
-                                ctypes.POINTER(daoType2CtypesType(self.image.md.contents.atype)))
-            #data=np.ctypeslib.as_array(arrayPtr, shape=(self.image.md.contents.nelement,)).astype(daoType2NpType(self.image.md.contents.atype))
+                                ctypes.POINTER(daoType2CtypesType(self.image.base_md.contents.atype)))
+            #data=np.ctypeslib.as_array(arrayPtr, shape=(self.image.base_md.contents.nelement,)).astype(daoType2NpType(self.image.base_md.contents.atype))
             if arraySize[2] == 0:
                 if arraySize[1] == 0:
-                    data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0],))#.astype(daoType2NpType(self.image.md.contents.atype))
+                    data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0],))#.astype(daoType2NpType(self.image.base_md.contents.atype))
                 else:
-                    data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1]))#.astype(daoType2NpType(self.image.md.contents.atype))
+                    data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1]))#.astype(daoType2NpType(self.image.base_md.contents.atype))
             else:
-                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1], arraySize[2]))#.astype(daoType2NpType(self.image.md.contents.atype))
+                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1], arraySize[2]))#.astype(daoType2NpType(self.image.base_md.contents.atype))
 
             # Check if the dtype is structured (i.e., for complex types)
             if data.dtype.fields is not None and 'real' in data.dtype.fields and 'imag' in data.dtype.fields:
@@ -613,7 +617,7 @@ class shm:
                 data = data['real'] + 1j * data['imag']
             
             # Cast to the desired NumPy type (e.g., complex64, complex128, or float, or...)
-            data = data.astype(daoType2NpType(self.image.md.contents.atype))
+            data = data.astype(daoType2NpType(self.image.base_md.contents.atype))
         
         return (result, data)
     
@@ -629,7 +633,7 @@ class shm:
         -------------------------------------------------------------- '''
 
         # First, check the requested number of items is valid
-        fifo_size = self.image.md[0].fifo_size
+        fifo_size = self.image.base_md[0].fifo_size
         fifo_idx = index % fifo_size
         
         arrayPtr = ctypes.c_void_p(None)
@@ -639,20 +643,20 @@ class shm:
 
         # Cast our void pointer to the desired type
         arrayPtr = ctypes.cast(arrayPtr.value,\
-                               ctypes.POINTER(daoType2CtypesType(self.image.md.contents.atype)))
+                               ctypes.POINTER(daoType2CtypesType(self.image.base_md.contents.atype)))
 
         # Get the array size
-        arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.md.contents.size,\
+        arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.base_md.contents.size,\
                                                       ctypes.POINTER(ctypes.c_uint32)), shape=(3,))
 
-        #data=np.ctypeslib.as_array(arrayPtr, shape=(self.image.md.contents.nelement,)).astype(daoType2NpType(self.image.md.contents.atype))
+        #data=np.ctypeslib.as_array(arrayPtr, shape=(self.image.base_md.contents.nelement,)).astype(daoType2NpType(self.image.base_md.contents.atype))
         if arraySize[2] == 0:
             if arraySize[1] == 0:
-                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0],))#.astype(daoType2NpType(self.image.md.contents.atype))
+                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0],))#.astype(daoType2NpType(self.image.base_md.contents.atype))
             else:
-                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1]))#.astype(daoType2NpType(self.image.md.contents.atype))
+                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1]))#.astype(daoType2NpType(self.image.base_md.contents.atype))
         else:
-            data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1], arraySize[2]))#.astype(daoType2NpType(self.image.md.contents.atype))
+            data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1], arraySize[2]))#.astype(daoType2NpType(self.image.base_md.contents.atype))
 
         # Check if the dtype is structured (i.e., for complex types)
         if data.dtype.fields is not None and 'real' in data.dtype.fields and 'imag' in data.dtype.fields:
@@ -660,7 +664,7 @@ class shm:
             data = data['real'] + 1j * data['imag']
         
         # Cast to the desired NumPy type (e.g., complex64, complex128, or float, or...)
-        data = data.astype(daoType2NpType(self.image.md.contents.atype))
+        data = data.astype(daoType2NpType(self.image.base_md.contents.atype))
 
         return data
     
@@ -696,20 +700,20 @@ class shm:
         
         # Cast our void pointer to the desired type
         arrayPtr = ctypes.cast(arrayPtr.value,\
-                               ctypes.POINTER(daoType2CtypesType(self.image.md.contents.atype)))
+                               ctypes.POINTER(daoType2CtypesType(self.image.base_md.contents.atype)))
 
         # Get the array size
-        arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.md.contents.size,\
+        arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.base_md.contents.size,\
                                                       ctypes.POINTER(ctypes.c_uint32)), shape=(3,))
 
-        #data=np.ctypeslib.as_array(arrayPtr, shape=(self.image.md.contents.nelement,)).astype(daoType2NpType(self.image.md.contents.atype))
+        #data=np.ctypeslib.as_array(arrayPtr, shape=(self.image.base_md.contents.nelement,)).astype(daoType2NpType(self.image.base_md.contents.atype))
         if arraySize[2] == 0:
             if arraySize[1] == 0:
-                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0],))#.astype(daoType2NpType(self.image.md.contents.atype))
+                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0],))#.astype(daoType2NpType(self.image.base_md.contents.atype))
             else:
-                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1]))#.astype(daoType2NpType(self.image.md.contents.atype))
+                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1]))#.astype(daoType2NpType(self.image.base_md.contents.atype))
         else:
-            data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1], arraySize[2]))#.astype(daoType2NpType(self.image.md.contents.atype))
+            data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1], arraySize[2]))#.astype(daoType2NpType(self.image.base_md.contents.atype))
 
         # Check if the dtype is structured (i.e., for complex types)
         if data.dtype.fields is not None and 'real' in data.dtype.fields and 'imag' in data.dtype.fields:
@@ -717,7 +721,7 @@ class shm:
             data = data['real'] + 1j * data['imag']
         
         # Cast to the desired NumPy type (e.g., complex64, complex128, or float, or...)
-        data = data.astype(daoType2NpType(self.image.md.contents.atype))
+        data = data.astype(daoType2NpType(self.image.base_md.contents.atype))
 
         return data
 
@@ -733,7 +737,7 @@ class shm:
         -------------------------------------------------------------- '''
 
         # First, check the requested number of items is valid
-        fifo_size = self.image.md[0].fifo_size
+        fifo_size = self.image.base_md[0].fifo_size
 
         if (num_items < 1):
             log.error("Cannot read less than 1 item")
@@ -743,7 +747,7 @@ class shm:
             return None
 
         # Now determine the size of array to reserve
-        arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.md.contents.size,\
+        arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.base_md.contents.size,\
                                                       ctypes.POINTER(ctypes.c_uint32)), shape=(3,))
         
         if arraySize[2] == 0:
@@ -754,12 +758,12 @@ class shm:
         else:
             result_shape = (num_items, arraySize[0], arraySize[1], arraySize[2])
 
-        history_data = np.empty(result_shape, dtype=daoType2NpType(self.image.md.contents.atype))
+        history_data = np.empty(result_shape, dtype=daoType2NpType(self.image.base_md.contents.atype))
 
         # Determine the index to read backwards from
-        idx_base = self.image.md[0].fifo_last_written - num_items + 1
+        idx_base = self.image.base_md[0].fifo_last_written - num_items + 1
 
-        element_ctype = daoType2CtypesType(self.image.md.contents.atype)
+        element_ctype = daoType2CtypesType(self.image.base_md.contents.atype)
 
         for idx_offset in range(num_items):
             # Calculate index
@@ -780,7 +784,7 @@ class shm:
             history_data[idx_offset] = current_data 
 
         # Cast to the desired NumPy type (e.g., complex64, complex128, or float, or...)
-        history_data = history_data.astype(daoType2NpType(self.image.md.contents.atype))
+        history_data = history_data.astype(daoType2NpType(self.image.base_md.contents.atype))
 
         return history_data
 
@@ -808,11 +812,11 @@ class shm:
                                         ctypes.byref(seg_cnt0))
         else:
             # get requested metadata from FIFO
-            fifo_size = self.image.md.contents.fifo_size
+            fifo_size = self.image.base_md.contents.fifo_size
             adjusted_index = index % fifo_size
             seg_idx = ctypes.c_uint32(adjusted_index)
 
-        md = self.image.md[seg_idx.value]
+        md = self.image.base_md[seg_idx.value]
         self.mtdata=struct2Dict(md)
 
         #decode time
@@ -831,8 +835,8 @@ class shm:
         self.mtdata['atime'] = mdts
 
         # Graft current FIFO values into this metadata from image->md[0]
-        self.mtdata['fifo_last_written'] = self.image.md.contents.fifo_last_written
-        self.mtdata['fifo_size'] = self.image.md.contents.fifo_size
+        self.mtdata['fifo_last_written'] = self.image.base_md.contents.fifo_last_written
+        self.mtdata['fifo_size'] = self.image.base_md.contents.fifo_size
 
         return self.mtdata
 

--- a/src/python/daoShm.py
+++ b/src/python/daoShm.py
@@ -514,21 +514,21 @@ class shm:
             log.error("Need at least a SHM name")
         elif data is not None:
             if depth < 1:
-                log.error("Depth can't be less than 1")
+                log.warning("Invalid depth passed (depth < 1). Forcing to 1...")
                 depth = 1
+
+            log.info("%s will be created or overwritten" % (fname,))
+            dataSize = data.shape
+            self.daoShmImageCreate_FIFO(ctypes.byref(self.image), fname.encode('utf-8'), len(dataSize),\
+                                (ctypes.c_uint32 * len(dataSize))(*dataSize),\
+                                npType2DaoType(data), 1, 0, depth)
+            if data.flags['C_CONTIGUOUS']:
+                cData = data.ctypes.data_as(ctypes.c_void_p)
             else:
-                log.info("%s will be created or overwritten" % (fname,))
-                dataSize = data.shape
-                self.daoShmImageCreate_FIFO(ctypes.byref(self.image), fname.encode('utf-8'), len(dataSize),\
-                                    (ctypes.c_uint32 * len(dataSize))(*dataSize),\
-                                    npType2DaoType(data), 1, 0, depth)
-                if data.flags['C_CONTIGUOUS']:
-                    cData = data.ctypes.data_as(ctypes.c_void_p)
-                else:
-                    cData = np.ascontiguousarray(data).ctypes.data_as(ctypes.c_void_p)
-                nbVal = ctypes.c_uint32(data.size)
-                # Call the daoShmImage2Shm function to feel the SHM
-                result = self.daoShmImage2Shm(cData, nbVal, ctypes.byref(self.image))
+                cData = np.ascontiguousarray(data).ctypes.data_as(ctypes.c_void_p)
+            nbVal = ctypes.c_uint32(data.size)
+            # Call the daoShmImage2Shm function to feel the SHM
+            result = self.daoShmImage2Shm(cData, nbVal, ctypes.byref(self.image))
         else:
             # log.info("loading existing %s " % (fname))
             result = self.daoShmShm2Img(fname.encode('utf-8'), ctypes.byref(self.image))

--- a/src/python/daoShm.py
+++ b/src/python/daoShm.py
@@ -899,7 +899,13 @@ class shm:
         ''' --------------------------------------------------------------
         Reset the reading tail for this instance of the SHM
         -------------------------------------------------------------- '''
-        result = self.daoShmResetTail(ctypes.byref(self.image))
+        tail_index = ctypes.c_uint32()
+        tail_timestamp = ctypes.c_uint64()
+        result = self.daoShmResetTail(
+            ctypes.byref(self.image),
+            ctypes.byref(tail_index),
+            ctypes.byref(tail_timestamp)
+        )
         return result
 
     def publish(self):

--- a/src/python/daoShm.py
+++ b/src/python/daoShm.py
@@ -340,7 +340,7 @@ else:
         ]
 
 class shm:
-    def __init__(self, fname=None, data=None, nbkw=0, pubPort=5555, subPort=5555, subHost='localhost', logLevel=1):
+    def __init__(self, fname=None, data=None, nbkw=0, pubPort=5555, subPort=5555, subHost='localhost', logLevel=1, depth=1):
         # int8_t daoShmInit1D(const char *name, char *prefix, uint32_t nbVal, IMAGE **image);
         self.daoShmInit1D = daoLib.daoShmInit1D
         self.daoShmInit1D.argtypes = [
@@ -399,6 +399,22 @@ class shm:
         self.daoShmImagePart2ShmFinalize.argtypes = [ctypes.POINTER(IMAGE)]
         self.daoShmImagePart2ShmFinalize.restype = ctypes.c_int8
 
+
+        # int8_t daoShmImageCreate_FIFO(IMAGE *image, const char *name, long naxis, uint32_t *size,
+        #                              uint8_t atype, int shared, int NBkw);
+        self.daoShmImageCreate_FIFO = daoLib.daoShmImageCreate_FIFO
+        self.daoShmImageCreate_FIFO.argtypes = [
+            ctypes.POINTER(IMAGE),
+            ctypes.c_char_p,
+            ctypes.c_long,
+            ctypes.POINTER(ctypes.c_uint32),
+            ctypes.c_uint8,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_uint32
+        ]
+        self.daoShmImageCreate_FIFO.restype = ctypes.c_int8
+
         # int8_t daoShmImageCreate(IMAGE *image, const char *name, long naxis, uint32_t *size,
         #                              uint8_t atype, int shared, int NBkw);
         self.daoShmImageCreate = daoLib.daoShmImageCreate
@@ -456,18 +472,21 @@ class shm:
         if fname == '':
             log.error("Need at least a SHM name")
         elif data is not None:
-            log.info("%s will be created or overwritten" % (fname,))
-            dataSize = data.shape
-            self.daoShmImageCreate(ctypes.byref(self.image), fname.encode('utf-8'), len(dataSize),\
-                                   (ctypes.c_uint32 * len(dataSize))(*dataSize),\
-                                   npType2DaoType(data), 1, 0)
-            if data.flags['C_CONTIGUOUS']:
-                cData = data.ctypes.data_as(ctypes.c_void_p)
+            if depth < 1:
+                log.error("Depth can't be less than 1")
             else:
-                cData = np.ascontiguousarray(data).ctypes.data_as(ctypes.c_void_p)
-            nbVal = ctypes.c_uint32(data.size)
-            # Call the daoShmImage2Shm function to feel the SHM
-            result = self.daoShmImage2Shm(cData, nbVal, ctypes.byref(self.image))
+                log.info("%s will be created or overwritten" % (fname,))
+                dataSize = data.shape
+                self.daoShmImageCreate_FIFO(ctypes.byref(self.image), fname.encode('utf-8'), len(dataSize),\
+                                    (ctypes.c_uint32 * len(dataSize))(*dataSize),\
+                                    npType2DaoType(data), 1, 0, depth)
+                if data.flags['C_CONTIGUOUS']:
+                    cData = data.ctypes.data_as(ctypes.c_void_p)
+                else:
+                    cData = np.ascontiguousarray(data).ctypes.data_as(ctypes.c_void_p)
+                nbVal = ctypes.c_uint32(data.size)
+                # Call the daoShmImage2Shm function to feel the SHM
+                result = self.daoShmImage2Shm(cData, nbVal, ctypes.byref(self.image))
         else:
             # log.info("loading existing %s " % (fname))
             result = self.daoShmShm2Img(fname.encode('utf-8'), ctypes.byref(self.image))

--- a/src/python/daoShm.py
+++ b/src/python/daoShm.py
@@ -309,9 +309,7 @@ if sys.platform == "win32":
             ('semWritePID', ctypes.POINTER(ctypes.c_int32)),
             ('shmfm', ctypes.POINTER(ctypes.c_void_p)),
             ('fifo_last_read', ctypes.c_uint32),
-            ('fifo_last_read_cnt0', ctypes.c_uint64),
-            ('base_array', ctypes.c_void_p),
-            ('base_md', ctypes.POINTER(IMAGE_METADATA))
+            ('fifo_last_read_cnt0', ctypes.c_uint64)
         ]
 else:
     # Define the IMAGE structure
@@ -346,9 +344,7 @@ else:
             ('semReadPID', ctypes.POINTER(ctypes.c_int32)),
             ('semWritePID', ctypes.POINTER(ctypes.c_int32)),
             ('fifo_last_read', ctypes.c_uint32),
-            ('fifo_last_read_cnt0', ctypes.c_uint64),
-            ('base_array', ctypes.c_void_p),
-            ('base_md', ctypes.POINTER(IMAGE_METADATA))
+            ('fifo_last_read_cnt0', ctypes.c_uint64)
         ]
 
 class shm:
@@ -597,19 +593,19 @@ class shm:
         data = None
         
         if result == self.DAO_SUCCESS or result == self.DAO_OVERWRITE:
-            arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.base_md.contents.size,\
+            arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.md.contents.size,\
                                                         ctypes.POINTER(ctypes.c_uint32)), shape=(3,))
 
             arrayPtr = ctypes.cast(arrayPtr,\
-                                ctypes.POINTER(daoType2CtypesType(self.image.base_md.contents.atype)))
-            #data=np.ctypeslib.as_array(arrayPtr, shape=(self.image.base_md.contents.nelement,)).astype(daoType2NpType(self.image.base_md.contents.atype))
+                                ctypes.POINTER(daoType2CtypesType(self.image.md.contents.atype)))
+            #data=np.ctypeslib.as_array(arrayPtr, shape=(self.image.md.contents.nelement,)).astype(daoType2NpType(self.image.md.contents.atype))
             if arraySize[2] == 0:
                 if arraySize[1] == 0:
-                    data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0],))#.astype(daoType2NpType(self.image.base_md.contents.atype))
+                    data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0],))#.astype(daoType2NpType(self.image.md.contents.atype))
                 else:
-                    data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1]))#.astype(daoType2NpType(self.image.base_md.contents.atype))
+                    data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1]))#.astype(daoType2NpType(self.image.md.contents.atype))
             else:
-                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1], arraySize[2]))#.astype(daoType2NpType(self.image.base_md.contents.atype))
+                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1], arraySize[2]))#.astype(daoType2NpType(self.image.md.contents.atype))
 
             # Check if the dtype is structured (i.e., for complex types)
             if data.dtype.fields is not None and 'real' in data.dtype.fields and 'imag' in data.dtype.fields:
@@ -617,7 +613,7 @@ class shm:
                 data = data['real'] + 1j * data['imag']
             
             # Cast to the desired NumPy type (e.g., complex64, complex128, or float, or...)
-            data = data.astype(daoType2NpType(self.image.base_md.contents.atype))
+            data = data.astype(daoType2NpType(self.image.md.contents.atype))
         
         return (result, data)
     
@@ -633,7 +629,7 @@ class shm:
         -------------------------------------------------------------- '''
 
         # First, check the requested number of items is valid
-        fifo_size = self.image.base_md[0].fifo_size
+        fifo_size = self.image.md[0].fifo_size
         fifo_idx = index % fifo_size
         
         arrayPtr = ctypes.c_void_p(None)
@@ -643,20 +639,20 @@ class shm:
 
         # Cast our void pointer to the desired type
         arrayPtr = ctypes.cast(arrayPtr.value,\
-                               ctypes.POINTER(daoType2CtypesType(self.image.base_md.contents.atype)))
+                               ctypes.POINTER(daoType2CtypesType(self.image.md.contents.atype)))
 
         # Get the array size
-        arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.base_md.contents.size,\
+        arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.md.contents.size,\
                                                       ctypes.POINTER(ctypes.c_uint32)), shape=(3,))
 
-        #data=np.ctypeslib.as_array(arrayPtr, shape=(self.image.base_md.contents.nelement,)).astype(daoType2NpType(self.image.base_md.contents.atype))
+        #data=np.ctypeslib.as_array(arrayPtr, shape=(self.image.md.contents.nelement,)).astype(daoType2NpType(self.image.md.contents.atype))
         if arraySize[2] == 0:
             if arraySize[1] == 0:
-                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0],))#.astype(daoType2NpType(self.image.base_md.contents.atype))
+                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0],))#.astype(daoType2NpType(self.image.md.contents.atype))
             else:
-                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1]))#.astype(daoType2NpType(self.image.base_md.contents.atype))
+                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1]))#.astype(daoType2NpType(self.image.md.contents.atype))
         else:
-            data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1], arraySize[2]))#.astype(daoType2NpType(self.image.base_md.contents.atype))
+            data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1], arraySize[2]))#.astype(daoType2NpType(self.image.md.contents.atype))
 
         # Check if the dtype is structured (i.e., for complex types)
         if data.dtype.fields is not None and 'real' in data.dtype.fields and 'imag' in data.dtype.fields:
@@ -664,7 +660,7 @@ class shm:
             data = data['real'] + 1j * data['imag']
         
         # Cast to the desired NumPy type (e.g., complex64, complex128, or float, or...)
-        data = data.astype(daoType2NpType(self.image.base_md.contents.atype))
+        data = data.astype(daoType2NpType(self.image.md.contents.atype))
 
         return data
     
@@ -700,20 +696,20 @@ class shm:
         
         # Cast our void pointer to the desired type
         arrayPtr = ctypes.cast(arrayPtr.value,\
-                               ctypes.POINTER(daoType2CtypesType(self.image.base_md.contents.atype)))
+                               ctypes.POINTER(daoType2CtypesType(self.image.md.contents.atype)))
 
         # Get the array size
-        arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.base_md.contents.size,\
+        arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.md.contents.size,\
                                                       ctypes.POINTER(ctypes.c_uint32)), shape=(3,))
 
-        #data=np.ctypeslib.as_array(arrayPtr, shape=(self.image.base_md.contents.nelement,)).astype(daoType2NpType(self.image.base_md.contents.atype))
+        #data=np.ctypeslib.as_array(arrayPtr, shape=(self.image.md.contents.nelement,)).astype(daoType2NpType(self.image.md.contents.atype))
         if arraySize[2] == 0:
             if arraySize[1] == 0:
-                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0],))#.astype(daoType2NpType(self.image.base_md.contents.atype))
+                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0],))#.astype(daoType2NpType(self.image.md.contents.atype))
             else:
-                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1]))#.astype(daoType2NpType(self.image.base_md.contents.atype))
+                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1]))#.astype(daoType2NpType(self.image.md.contents.atype))
         else:
-            data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1], arraySize[2]))#.astype(daoType2NpType(self.image.base_md.contents.atype))
+            data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1], arraySize[2]))#.astype(daoType2NpType(self.image.md.contents.atype))
 
         # Check if the dtype is structured (i.e., for complex types)
         if data.dtype.fields is not None and 'real' in data.dtype.fields and 'imag' in data.dtype.fields:
@@ -721,7 +717,7 @@ class shm:
             data = data['real'] + 1j * data['imag']
         
         # Cast to the desired NumPy type (e.g., complex64, complex128, or float, or...)
-        data = data.astype(daoType2NpType(self.image.base_md.contents.atype))
+        data = data.astype(daoType2NpType(self.image.md.contents.atype))
 
         return data
 
@@ -737,7 +733,7 @@ class shm:
         -------------------------------------------------------------- '''
 
         # First, check the requested number of items is valid
-        fifo_size = self.image.base_md[0].fifo_size
+        fifo_size = self.image.md[0].fifo_size
 
         if (num_items < 1):
             log.error("Cannot read less than 1 item")
@@ -747,7 +743,7 @@ class shm:
             return None
 
         # Now determine the size of array to reserve
-        arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.base_md.contents.size,\
+        arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.md.contents.size,\
                                                       ctypes.POINTER(ctypes.c_uint32)), shape=(3,))
         
         if arraySize[2] == 0:
@@ -758,12 +754,12 @@ class shm:
         else:
             result_shape = (num_items, arraySize[0], arraySize[1], arraySize[2])
 
-        history_data = np.empty(result_shape, dtype=daoType2NpType(self.image.base_md.contents.atype))
+        history_data = np.empty(result_shape, dtype=daoType2NpType(self.image.md.contents.atype))
 
         # Determine the index to read backwards from
-        idx_base = self.image.base_md[0].fifo_last_written - num_items + 1
+        idx_base = self.image.md[0].fifo_last_written - num_items + 1
 
-        element_ctype = daoType2CtypesType(self.image.base_md.contents.atype)
+        element_ctype = daoType2CtypesType(self.image.md.contents.atype)
 
         for idx_offset in range(num_items):
             # Calculate index
@@ -784,7 +780,7 @@ class shm:
             history_data[idx_offset] = current_data 
 
         # Cast to the desired NumPy type (e.g., complex64, complex128, or float, or...)
-        history_data = history_data.astype(daoType2NpType(self.image.base_md.contents.atype))
+        history_data = history_data.astype(daoType2NpType(self.image.md.contents.atype))
 
         return history_data
 
@@ -812,11 +808,11 @@ class shm:
                                         ctypes.byref(seg_cnt0))
         else:
             # get requested metadata from FIFO
-            fifo_size = self.image.base_md.contents.fifo_size
+            fifo_size = self.image.md.contents.fifo_size
             adjusted_index = index % fifo_size
             seg_idx = ctypes.c_uint32(adjusted_index)
 
-        md = self.image.base_md[seg_idx.value]
+        md = self.image.md[seg_idx.value]
         self.mtdata=struct2Dict(md)
 
         #decode time
@@ -835,8 +831,8 @@ class shm:
         self.mtdata['atime'] = mdts
 
         # Graft current FIFO values into this metadata from image->md[0]
-        self.mtdata['fifo_last_written'] = self.image.base_md.contents.fifo_last_written
-        self.mtdata['fifo_size'] = self.image.base_md.contents.fifo_size
+        self.mtdata['fifo_last_written'] = self.image.md.contents.fifo_last_written
+        self.mtdata['fifo_size'] = self.image.md.contents.fifo_size
 
         return self.mtdata
 

--- a/src/python/daoShm.py
+++ b/src/python/daoShm.py
@@ -617,9 +617,57 @@ class shm:
         
         return (result, data)
     
+
+    def get_data_arbitrary(self, index):
+        ''' --------------------------------------------------------------
+        Reads and returns the requested data segment of the SHM file
+
+        Parameters:
+        ----------
+        - wait: integer (last index) if not False, waits image update
+        - reform: boolean, if True, reshapes the array in a 2-3D format
+        -------------------------------------------------------------- '''
+
+        # First, check the requested number of items is valid
+        fifo_size = self.image.md[0].fifo_size
+        fifo_idx = index % fifo_size
+        
+        arrayPtr = ctypes.c_void_p(None)
+        
+        result = self.daoShmGetArbitrarySegment(ctypes.byref(self.image), ctypes.byref(arrayPtr),\
+                                           ctypes.c_uint32(fifo_idx))
+
+        # Cast our void pointer to the desired type
+        arrayPtr = ctypes.cast(arrayPtr.value,\
+                               ctypes.POINTER(daoType2CtypesType(self.image.md.contents.atype)))
+
+        # Get the array size
+        arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.md.contents.size,\
+                                                      ctypes.POINTER(ctypes.c_uint32)), shape=(3,))
+
+        #data=np.ctypeslib.as_array(arrayPtr, shape=(self.image.md.contents.nelement,)).astype(daoType2NpType(self.image.md.contents.atype))
+        if arraySize[2] == 0:
+            if arraySize[1] == 0:
+                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0],))#.astype(daoType2NpType(self.image.md.contents.atype))
+            else:
+                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1]))#.astype(daoType2NpType(self.image.md.contents.atype))
+        else:
+            data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1], arraySize[2]))#.astype(daoType2NpType(self.image.md.contents.atype))
+
+        # Check if the dtype is structured (i.e., for complex types)
+        if data.dtype.fields is not None and 'real' in data.dtype.fields and 'imag' in data.dtype.fields:
+            # Reconstruct complex array by combining real and imaginary parts
+            data = data['real'] + 1j * data['imag']
+        
+        # Cast to the desired NumPy type (e.g., complex64, complex128, or float, or...)
+        data = data.astype(daoType2NpType(self.image.md.contents.atype))
+
+        return data
+    
+
     def get_data(self, check=False, reform=True, semNb=0, timeout=0, spin=False):
         ''' --------------------------------------------------------------
-        Reads and returns the data part of the SHM file
+        Reads and returns the newest data segment of the SHM file
 
         Parameters:
         ----------
@@ -639,11 +687,21 @@ class shm:
                         log.error("Timeout waiting for semaphore")
                         return None
 
+        arrayPtr = ctypes.c_void_p(None)
+        seg_idx = ctypes.c_uint32(0)
+        seg_cnt0 = ctypes.c_uint64(0)
+        
+        result = self.daoShmGetNewestSegment(ctypes.byref(self.image), ctypes.byref(arrayPtr),\
+                                           ctypes.byref(seg_idx), ctypes.byref(seg_cnt0))
+        
+        # Cast our void pointer to the desired type
+        arrayPtr = ctypes.cast(arrayPtr.value,\
+                               ctypes.POINTER(daoType2CtypesType(self.image.md.contents.atype)))
+
+        # Get the array size
         arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.md.contents.size,\
                                                       ctypes.POINTER(ctypes.c_uint32)), shape=(3,))
 
-        arrayPtr = ctypes.cast(self.image.array,\
-                               ctypes.POINTER(daoType2CtypesType(self.image.md.contents.atype)))
         #data=np.ctypeslib.as_array(arrayPtr, shape=(self.image.md.contents.nelement,)).astype(daoType2NpType(self.image.md.contents.atype))
         if arraySize[2] == 0:
             if arraySize[1] == 0:
@@ -729,7 +787,7 @@ class shm:
 
 
 
-    def get_meta_data(self):
+    def get_meta_data(self, index=None):
         ''' --------------------------------------------------------------
         Get the metadata fraction of the SHM file.
         Populate the shm object mtdata dictionary.
@@ -738,15 +796,22 @@ class shm:
         ----------
         - verbose: (boolean, default: True), prints its findings
         -------------------------------------------------------------- '''
-        # get latest metadata from FIFO
-        seg_ptr = ctypes.c_void_p(None)
-        seg_idx = ctypes.c_uint32(0)
-        seg_cnt0 = ctypes.c_uint64(0)
 
-        self.daoShmGetNewestSegment(ctypes.byref(self.image),\
-                                    ctypes.byref(seg_ptr),\
-                                    ctypes.byref(seg_idx),
-                                    ctypes.byref(seg_cnt0))
+        if (index == None):
+            # get latest metadata from FIFO
+            seg_ptr = ctypes.c_void_p(None)
+            seg_idx = ctypes.c_uint32(0)
+            seg_cnt0 = ctypes.c_uint64(0)
+
+            self.daoShmGetNewestSegment(ctypes.byref(self.image),\
+                                        ctypes.byref(seg_ptr),\
+                                        ctypes.byref(seg_idx),
+                                        ctypes.byref(seg_cnt0))
+        else:
+            # get requested metadata from FIFO
+            fifo_size = self.image.md.contents.fifo_size
+            adjusted_index = index % fifo_size
+            seg_idx = ctypes.c_uint32(adjusted_index)
 
         md = self.image.md[seg_idx.value]
         self.mtdata=struct2Dict(md)

--- a/src/python/daoShm.py
+++ b/src/python/daoShm.py
@@ -310,8 +310,8 @@ if sys.platform == "win32":
             ('shmfm', ctypes.POINTER(ctypes.c_void_p)),
             ('fifo_last_read', ctypes.c_uint32),
             ('fifo_last_read_cnt0', ctypes.c_uint64),
-            ('base_array', ctypes.c_void_p)
-            ('base_md', ctypes.c_void_p)
+            ('base_array', ctypes.c_void_p),
+            ('base_md', ctypes.POINTER(IMAGE_METADATA))
         ]
 else:
     # Define the IMAGE structure
@@ -348,7 +348,7 @@ else:
             ('fifo_last_read', ctypes.c_uint32),
             ('fifo_last_read_cnt0', ctypes.c_uint64),
             ('base_array', ctypes.c_void_p),
-            ('base_md', ctypes.c_void_p)
+            ('base_md', ctypes.POINTER(IMAGE_METADATA))
         ]
 
 class shm:

--- a/src/python/daoShm.py
+++ b/src/python/daoShm.py
@@ -759,20 +759,17 @@ class shm:
         # Determine the index to read backwards from
         idx_base = self.image.md[0].fifo_last_written - num_items + 1
 
-        array_base = self.image.array
-        
         element_ctype = daoType2CtypesType(self.image.md.contents.atype)
-        element_size = ctypes.sizeof(element_ctype)
-        nelement = self.image.md.contents.nelement
 
         for idx_offset in range(num_items):
             # Calculate index
             current_idx = (idx_base + idx_offset) % fifo_size
 
-            # Get corresponding segment pointer
-            array_ptr = element_ctype.from_address(array_base + (current_idx * nelement * element_size))
+            arrayPtr = ctypes.c_void_p(None)
+            self.daoShmGetArbitrarySegment(ctypes.byref(self.image), ctypes.byref(arrayPtr), ctypes.c_uint32(current_idx))
+            arrayPtr = ctypes.cast(arrayPtr.value, ctypes.POINTER(element_ctype))
             
-            current_data = np.ctypeslib.as_array(array_ptr, shape=result_shape[1:])
+            current_data = np.ctypeslib.as_array(arrayPtr, shape=result_shape[1:])
 
             if current_data.dtype.fields is not None \
                     and 'real' in current_data.dtype.fields \
@@ -780,7 +777,7 @@ class shm:
                 # Reconstruct complex array by combining real and imaginary parts
                 current_data = current_data['real'] + 1j * current_data['imag']
 
-            history_data[idx_offset] = current_data
+            history_data[idx_offset] = current_data 
 
         # Cast to the desired NumPy type (e.g., complex64, complex128, or float, or...)
         history_data = history_data.astype(daoType2NpType(self.image.md.contents.atype))

--- a/src/python/daoShm.py
+++ b/src/python/daoShm.py
@@ -672,7 +672,17 @@ class shm:
         ----------
         - verbose: (boolean, default: True), prints its findings
         -------------------------------------------------------------- '''
-        md=self.image.md.contents
+        # get latest metadata from FIFO
+        seg_ptr = ctypes.c_void_p(None)
+        seg_idx = ctypes.c_uint32(0)
+        seg_cnt0 = ctypes.c_uint64(0)
+
+        self.daoShmGetNewestSegment(ctypes.byref(self.image),\
+                                    ctypes.byref(seg_ptr),\
+                                    ctypes.byref(seg_idx),
+                                    ctypes.byref(seg_cnt0))
+
+        md = self.image.md[seg_idx.value]
         self.mtdata=struct2Dict(md)
 
         #decode time
@@ -689,6 +699,10 @@ class shm:
         mdts['tsfixed'] = mdt2s
 
         self.mtdata['atime'] = mdts
+
+        # Graft current FIFO values into this metadata from image->md[0]
+        self.mtdata['fifo_last_written'] = self.image.md.contents.fifo_last_written
+        self.mtdata['fifo_size'] = self.image.md.contents.fifo_size
 
         return self.mtdata
 
@@ -711,6 +725,13 @@ class shm:
 
         # now I have tv_sec and tv_nsec we convert to a datetime
         return datetime.datetime.fromtimestamp(tv_sec) + datetime.timedelta(microseconds=tv_nsec/1000)
+
+    def reset_tail(self, ):
+        ''' --------------------------------------------------------------
+        Reset the reading tail for this instance of the SHM
+        -------------------------------------------------------------- '''
+        result = self.daoShmResetTail(ctypes.byref(self.image))
+        return result
 
     def publish(self):
         self.pubContext = zmq.Context()

--- a/src/python/daoShm.py
+++ b/src/python/daoShm.py
@@ -201,7 +201,7 @@ class IMAGE_KEYWORD(ctypes.Structure):
     ]
 
 # Define the IMAGE_METADATA structure
-if sys.platform == "Darwin":
+if sys.platform == "darwin":
     # Define the IMAGE_METADATA structure
     class IMAGE_METADATA(ctypes.Structure):
         class ATIME(ctypes.Union):

--- a/src/python/daoShm.py
+++ b/src/python/daoShm.py
@@ -774,9 +774,11 @@ class shm:
             
             current_data = np.ctypeslib.as_array(array_ptr, shape=result_shape[1:])
 
-            if current_data.dtype.fields is not None and 'real' in data.dtype.fields and 'imag' in current_data.dtype.fields:
+            if current_data.dtype.fields is not None \
+                    and 'real' in current_data.dtype.fields \
+                    and 'imag' in current_data.dtype.fields:
                 # Reconstruct complex array by combining real and imaginary parts
-                data = data['real'] + 1j * data['imag']
+                current_data = current_data['real'] + 1j * current_data['imag']
 
             history_data[idx_offset] = current_data
 

--- a/src/python/daoShm.py
+++ b/src/python/daoShm.py
@@ -729,13 +729,19 @@ class shm:
 
 
 
-    def get_history(self, num_items=1):
+    def get_history(self, num_items=1, check=False, semNb=0, timeout=0, spin=False, buffer=False):
         ''' --------------------------------------------------------------
         Reads and returns the last N segments written to the SHM
 
         Parameters:
         ----------
         - num_items: Number of items to return
+        - check:  if True, waits for the next semaphore post before reading history
+        - semNb:  semaphore number to wait on (used when check=True or buffer=True)
+        - timeout: seconds to wait for semaphore (0 = wait indefinitely)
+        - spin:   if True, use counter-based wait instead of semaphore
+        - buffer: if True, waits for num_items new writes since last call before
+                  returning the array (implies semaphore waiting per write)
         -------------------------------------------------------------- '''
 
         # First, check the requested number of items is valid
@@ -747,6 +753,33 @@ class shm:
         elif (num_items > fifo_size):
             log.error("Cannot read more segments than exist")
             return None
+
+        def _wait_one():
+            """Wait for a single new semaphore post. Returns False on timeout."""
+            if spin:
+                self.daoShmWaitForCounter(ctypes.byref(self.image))
+            else:
+                if timeout == 0:
+                    result = -1
+                    while result == -1:
+                        result = self.daoShmWaitForSemaphore(ctypes.byref(self.image), semNb)
+                else:
+                    ts = make_timespec_from_now(timeout)
+                    result = self.daoShmWaitForSemaphoreTimeout(ctypes.byref(self.image), semNb, ctypes.byref(ts))
+                    if result != 0:
+                        log.error("Timeout waiting for semaphore")
+                        return False
+            return True
+
+        if buffer:
+            # Accumulate num_items new writes before reading
+            for _ in range(num_items):
+                if not _wait_one():
+                    return None
+        elif check:
+            # Wait for the next semaphore post (next write) before reading
+            if not _wait_one():
+                return None
 
         # Now determine the size of array to reserve
         arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.md.contents.size,\

--- a/src/python/daoShm.py
+++ b/src/python/daoShm.py
@@ -567,13 +567,13 @@ class shm:
         nbVal = ctypes.c_uint32(data.size)
         result = self.daoShmImage2Shm(cData, nbVal, ctypes.byref(self.image))
 
-    def get_data_next(self, wait=False, reform=True, semNb=0, timeout=0):
+    def get_data_next(self, wait=False, reform=True):
         ''' --------------------------------------------------------------
         Reads and returns the next data part of the SHM file
 
         Parameters:
         ----------
-        - check: integer (last index) if not False, waits image update
+        - wait: integer (last index) if not False, waits image update
         - reform: boolean, if True, reshapes the array in a 2-3D format
         -------------------------------------------------------------- '''
 
@@ -616,7 +616,7 @@ class shm:
             data = data.astype(daoType2NpType(self.image.md.contents.atype))
         
         return (result, data)
-
+    
     def get_data(self, check=False, reform=True, semNb=0, timeout=0, spin=False):
         ''' --------------------------------------------------------------
         Reads and returns the data part of the SHM file
@@ -662,6 +662,72 @@ class shm:
         data = data.astype(daoType2NpType(self.image.md.contents.atype))
 
         return data
+
+
+
+    def get_history(self, num_items=1):
+        ''' --------------------------------------------------------------
+        Reads and returns the last N segments written to the SHM
+
+        Parameters:
+        ----------
+        - num_items: Number of items to return
+        -------------------------------------------------------------- '''
+
+        # First, check the requested number of items is valid
+        fifo_size = self.image.md[0].fifo_size
+
+        if (num_items < 1):
+            log.error("Cannot read less than 1 item")
+            return None
+        elif (num_items > fifo_size):
+            log.error("Cannot read more segments than exist")
+            return None
+
+        # Now determine the size of array to reserve
+        arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.md.contents.size,\
+                                                      ctypes.POINTER(ctypes.c_uint32)), shape=(3,))
+        
+        if arraySize[2] == 0:
+            if arraySize[1] == 0:
+                result_shape = (num_items, arraySize[0],)
+            else:
+                result_shape = (num_items, arraySize[0], arraySize[1],)
+        else:
+            result_shape = (num_items, arraySize[0], arraySize[1], arraySize[2])
+
+        history_data = np.empty(result_shape, dtype=daoType2NpType(self.image.md.contents.atype))
+
+        # Determine the index to read backwards from
+        idx_base = self.image.md[0].fifo_last_written - num_items + 1
+
+        array_base = self.image.array
+        
+        element_ctype = daoType2CtypesType(self.image.md.contents.atype)
+        element_size = ctypes.sizeof(element_ctype)
+        nelement = self.image.md.contents.nelement
+
+        for idx_offset in range(num_items):
+            # Calculate index
+            current_idx = (idx_base + idx_offset) % fifo_size
+
+            # Get corresponding segment pointer
+            array_ptr = element_ctype.from_address(array_base + (current_idx * nelement * element_size))
+            
+            current_data = np.ctypeslib.as_array(array_ptr, shape=result_shape[1:])
+
+            if current_data.dtype.fields is not None and 'real' in data.dtype.fields and 'imag' in current_data.dtype.fields:
+                # Reconstruct complex array by combining real and imaginary parts
+                data = data['real'] + 1j * data['imag']
+
+            history_data[idx_offset] = current_data
+
+        # Cast to the desired NumPy type (e.g., complex64, complex128, or float, or...)
+        history_data = history_data.astype(daoType2NpType(self.image.md.contents.atype))
+
+        return history_data
+
+
 
     def get_meta_data(self):
         ''' --------------------------------------------------------------

--- a/src/python/daoShm.py
+++ b/src/python/daoShm.py
@@ -232,7 +232,11 @@ if sys.platform == "Darwin":
             ("lastNb", ctypes.c_uint32),
             ("packetNb", ctypes.c_uint32),
             ("packetTotal", ctypes.c_uint32),
-            ("lastNbArray", ctypes.c_uint64 * 512)
+            ("lastNbArray", ctypes.c_uint64 * 512),
+            ("semCounter", ctypes.c_uint32 * 10),
+            ("semLogCounter", ctypes.c_uint32),
+            ("fifo_size", ctypes.c_uint32),
+            ("fifo_last_written", ctypes.c_uint32)
         ]
 else:
     # Define the IMAGE_METADATA structure
@@ -266,8 +270,8 @@ else:
             ("packetNb", ctypes.c_uint32),
             ("packetTotal", ctypes.c_uint32),
             ("lastNbArray", ctypes.c_uint64 * 512),
-            ("semCounter", ctypes.c_uint32 * 10),
-            ("semLogCounter", ctypes.c_uint32)
+            ("fifo_size", ctypes.c_uint32),
+            ("fifo_last_written", ctypes.c_uint32)
         ]
     
 
@@ -303,7 +307,9 @@ if sys.platform == "win32":
             ('kw', ctypes.POINTER(IMAGE_KEYWORD)),
             ('semReadPID', ctypes.POINTER(ctypes.c_int32)),
             ('semWritePID', ctypes.POINTER(ctypes.c_int32)),
-            ('shmfm', ctypes.POINTER(ctypes.c_void_p))
+            ('shmfm', ctypes.POINTER(ctypes.c_void_p)),
+            ('fifo_last_read', ctypes.c_uint32),
+            ('fifo_last_read_cnt0', ctypes.c_uint64)
         ]
 else:
     # Define the IMAGE structure
@@ -336,10 +342,18 @@ else:
             ('semptr', ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p))),
             ('kw', ctypes.POINTER(IMAGE_KEYWORD)),
             ('semReadPID', ctypes.POINTER(ctypes.c_int32)),
-            ('semWritePID', ctypes.POINTER(ctypes.c_int32))
+            ('semWritePID', ctypes.POINTER(ctypes.c_int32)),
+            ('fifo_last_read', ctypes.c_uint32),
+            ('fifo_last_read_cnt0', ctypes.c_uint64)
         ]
 
 class shm:
+    DAO_SUCCESS = 0
+    DAO_ERROR = 1
+    DAO_TIMEOUT = -1
+    DAO_OVERWRITE = -2
+    DAO_NOTREADY = -3
+
     def __init__(self, fname=None, data=None, nbkw=0, pubPort=5555, subPort=5555, subHost='localhost', logLevel=1, depth=1):
         # int8_t daoShmInit1D(const char *name, char *prefix, uint32_t nbVal, IMAGE **image);
         self.daoShmInit1D = daoLib.daoShmInit1D
@@ -462,6 +476,33 @@ class shm:
         self.daoShmWaitForCounter = daoLib.daoShmWaitForCounter
         self.daoShmWaitForCounter.argtypes = [ctypes.POINTER(IMAGE)]
         self.daoShmWaitForCounter.restype = ctypes.c_int8
+
+        # new FIFO functions
+        self.daoShmGetNextSegment = daoLib.daoShmGetNextSegment
+        self.daoShmGetNextSegment.argtypes = [ctypes.POINTER(IMAGE), ctypes.POINTER(ctypes.c_void_p),\
+                                              ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint64)]
+        self.daoShmGetNextSegment.restype = ctypes.c_int8
+
+        self.daoShmWaitForNextSegment = daoLib.daoShmWaitForNextSegment
+        self.daoShmWaitForNextSegment.argtypes = [ctypes.POINTER(IMAGE)]
+        self.daoShmWaitForNextSegment.restype = ctypes.c_int8
+
+        self.daoShmGetArbitrarySegment = daoLib.daoShmGetArbitrarySegment
+        self.daoShmGetArbitrarySegment.argtypes = [ctypes.POINTER(IMAGE), ctypes.POINTER(ctypes.c_void_p), ctypes.c_uint32]
+        self.daoShmGetArbitrarySegment.restype = ctypes.c_int8
+
+        self.daoShmGetNewestSegment = daoLib.daoShmGetNewestSegment
+        self.daoShmGetNewestSegment.argtypes = [ctypes.POINTER(IMAGE), ctypes.POINTER(ctypes.c_void_p),\
+                                              ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint64)]
+        self.daoShmGetNewestSegment.restype = ctypes.c_int8
+
+        self.daoShmCheckSegmentOverwrite = daoLib.daoShmCheckSegmentOverwrite
+        self.daoShmCheckSegmentOverwrite.argtypes = [ctypes.POINTER(IMAGE)]
+        self.daoShmCheckSegmentOverwrite.restype = ctypes.c_int8
+
+        self.daoShmResetTail = daoLib.daoShmResetTail
+        self.daoShmResetTail.argtypes = [ctypes.POINTER(IMAGE), ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_uint64)]
+        self.daoShmResetTail.restype = ctypes.c_int8
         
         # int8_t daoShmCloseShm(IMAGE *image);
         self.daoShmCloseShm = daoLib.daoShmCloseShm
@@ -474,6 +515,7 @@ class shm:
         elif data is not None:
             if depth < 1:
                 log.error("Depth can't be less than 1")
+                depth = 1
             else:
                 log.info("%s will be created or overwritten" % (fname,))
                 dataSize = data.shape
@@ -524,6 +566,56 @@ class shm:
 
         nbVal = ctypes.c_uint32(data.size)
         result = self.daoShmImage2Shm(cData, nbVal, ctypes.byref(self.image))
+
+    def get_data_next(self, wait=False, reform=True, semNb=0, timeout=0):
+        ''' --------------------------------------------------------------
+        Reads and returns the next data part of the SHM file
+
+        Parameters:
+        ----------
+        - check: integer (last index) if not False, waits image update
+        - reform: boolean, if True, reshapes the array in a 2-3D format
+        -------------------------------------------------------------- '''
+
+        if wait == True:
+            result = self.daoShmWaitForNextSegment(ctypes.byref(self.image))
+            if result != 0:
+                log.error("Error waiting for counter")
+                return None
+        
+        arrayPtr = ctypes.c_void_p(None)
+        temp32 = ctypes.c_uint32()
+        temp64 = ctypes.c_uint64()
+        
+        result = self.daoShmGetNextSegment(ctypes.byref(self.image), ctypes.byref(arrayPtr),\
+                                           ctypes.byref(temp32),  ctypes.byref(temp64))
+        
+        data = None
+        
+        if result == self.DAO_SUCCESS or result == self.DAO_OVERWRITE:
+            arraySize = np.ctypeslib.as_array(ctypes.cast(self.image.md.contents.size,\
+                                                        ctypes.POINTER(ctypes.c_uint32)), shape=(3,))
+
+            arrayPtr = ctypes.cast(arrayPtr,\
+                                ctypes.POINTER(daoType2CtypesType(self.image.md.contents.atype)))
+            #data=np.ctypeslib.as_array(arrayPtr, shape=(self.image.md.contents.nelement,)).astype(daoType2NpType(self.image.md.contents.atype))
+            if arraySize[2] == 0:
+                if arraySize[1] == 0:
+                    data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0],))#.astype(daoType2NpType(self.image.md.contents.atype))
+                else:
+                    data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1]))#.astype(daoType2NpType(self.image.md.contents.atype))
+            else:
+                data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1], arraySize[2]))#.astype(daoType2NpType(self.image.md.contents.atype))
+
+            # Check if the dtype is structured (i.e., for complex types)
+            if data.dtype.fields is not None and 'real' in data.dtype.fields and 'imag' in data.dtype.fields:
+                # Reconstruct complex array by combining real and imaginary parts
+                data = data['real'] + 1j * data['imag']
+            
+            # Cast to the desired NumPy type (e.g., complex64, complex128, or float, or...)
+            data = data.astype(daoType2NpType(self.image.md.contents.atype))
+        
+        return (result, data)
 
     def get_data(self, check=False, reform=True, semNb=0, timeout=0, spin=False):
         ''' --------------------------------------------------------------

--- a/test/test_cppInterface.cpp
+++ b/test/test_cppInterface.cpp
@@ -13,6 +13,7 @@
 #include <thread>
 #include <future>
 #include <sstream>
+#include <chrono>
 
  /**
   * @brief Test fixture for providing and cleaning up a shared memory file path.
@@ -143,10 +144,10 @@ TEST_F(Suite, SpinSync)
         syncDone = true;
     });
 
-    sleep(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
     smem.set_frame(frame);
 
-    sleep(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
     ASSERT_EQ(syncDone, true);
     waiter.join();
 }
@@ -165,10 +166,10 @@ TEST_F(Suite, SpinSyncTimeout)
         syncDone = true;
     });
 
-    sleep(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
     smem.set_frame(frame);
 
-    sleep(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
     ASSERT_EQ(syncDone, true);
     waiter.join();
 }
@@ -187,10 +188,10 @@ TEST_F(Suite, SemSync)
         syncDone = true;
     });
 
-    sleep(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
     smem.set_frame(frame);
 
-    sleep(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
     ASSERT_EQ(syncDone, true);
     waiter.join();
 }
@@ -210,7 +211,7 @@ TEST_F(Suite, SemSyncTimeout)
         syncDone = true;
     });
 
-    sleep(timeout + 2);
+    std::this_thread::sleep_for(std::chrono::seconds(timeout + 2));
     ASSERT_EQ(syncDone, true);
     waiter.join();
 }
@@ -229,10 +230,10 @@ TEST_F(Suite, SemXSync)
         syncDone = true;
     });
 
-    sleep(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
     smem.set_frame(frame);
 
-    sleep(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
     ASSERT_EQ(syncDone, true);
     waiter.join();
 }
@@ -276,10 +277,10 @@ TEST_F(Suite, FifoSync)
         syncDone = true;
     });
 
-    sleep(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
     smem.set_frame(frame_b);
 
-    sleep(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
     ASSERT_EQ(syncDone, true);
     waiter.join();
 }
@@ -302,6 +303,9 @@ TEST_F(Suite, FifoOverwrite)
         int16_t *frame_ = smem.get_next_frame(true, status, cnt0_a);
         ASSERT_EQ(*frame_, 128);
 
+        // Wait for all writes to complete by spinning until cnt0 = cnt0_a + 10
+        smem.get_frame(Dao::ShmSync::SPIN, cnt0_a + 10);
+
         frame_ = smem.get_next_frame(true, status, cnt0_b);
         ASSERT_EQ(*frame_, 129);
 
@@ -310,12 +314,12 @@ TEST_F(Suite, FifoOverwrite)
         syncDone = true;
     });
 
-    sleep(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     for (int i = 0; i < 10; ++i)
         smem.set_frame(frame_b);
 
-    sleep(2);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
     ASSERT_EQ(syncDone, true);
     waiter.join();

--- a/test/test_cppInterface.cpp
+++ b/test/test_cppInterface.cpp
@@ -250,6 +250,77 @@ TEST_F(Suite, GetShape)
     ASSERT_EQ(std::memcmp(shape.data(), shape_.data(), shape.size() * sizeof(uint32_t)), 0);
 }
 
+/**
+ * @brief Ensure correct FIFO frame sync.
+ */
+TEST_F(Suite, FifoSync)
+{
+    bool syncDone = false;
+    int16_t frame_a[] = { 128 };
+    int16_t frame_b[] = { 129 };
+
+    Dao::Shm<int16_t> smem(shmPath_, { 1,1 }, frame_a, 4);
+
+    std::thread waiter ([&]() {
+        int_fast8_t status;
+        uint64_t cnt0_a, cnt0_b;
+
+        int16_t *frame_ = smem.get_next_frame(true, status, cnt0_a);
+        ASSERT_EQ(*frame_, 128);
+
+        frame_ = smem.get_next_frame(true, status, cnt0_b);
+        ASSERT_EQ(*frame_, 129);
+
+        ASSERT_EQ(cnt0_a + 1, cnt0_b);
+        ASSERT_EQ(status, DAO_SUCCESS);
+        syncDone = true;
+    });
+
+    sleep(1);
+    smem.set_frame(frame_b);
+
+    sleep(1);
+    ASSERT_EQ(syncDone, true);
+    waiter.join();
+}
+
+/**
+ * @brief Ensure correct FIFO overwrite detection
+ */
+TEST_F(Suite, FifoOverwrite)
+{
+    bool syncDone = false;
+    int16_t frame_a[] = { 128 };
+    int16_t frame_b[] = { 129 };
+
+    Dao::Shm<int16_t> smem(shmPath_, { 1,1 }, frame_a, 4);
+
+    std::thread waiter ([&]() {
+        int_fast8_t status;
+        uint64_t cnt0_a, cnt0_b;
+
+        int16_t *frame_ = smem.get_next_frame(true, status, cnt0_a);
+        ASSERT_EQ(*frame_, 128);
+
+        frame_ = smem.get_next_frame(true, status, cnt0_b);
+        ASSERT_EQ(*frame_, 129);
+
+        ASSERT_EQ(cnt0_a + 10, cnt0_b);
+        ASSERT_EQ(status, DAO_OVERWRITE);
+        syncDone = true;
+    });
+
+    sleep(1);
+
+    for (int i = 0; i < 10; ++i)
+        smem.set_frame(frame_b);
+
+    sleep(2);
+
+    ASSERT_EQ(syncDone, true);
+    waiter.join();
+}
+
 int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
This branch adds a FIFO (multi-depth ring buffer) capability to the DAO shared memory layer, spanning the C core, Python bindings, and C++ bindings.

### C Core
- Add `depth` parameter to SHM creation/loading to support FIFO buffers of configurable size
- Add functions for tracking the FIFO read tail and writing in segments
- Update counter functions to correctly handle FIFO SHMs
- Add FIFO support to `daoShmCombineShm2Shm` (both input and output sides)

### Python Bindings
- Add `depth` keyword to SHM creation
- Add `get_history(num_items)` to read the last N frames from the FIFO
- Add `get_data_arbitrary(index)` for arbitrary segment reads
- Update `get_data` to always return the newest segment
- Update `get_meta_data` to use the newest segment
- Add `reset_tail` to reset the read position
- Add `check`, `buffer`, `semNb`, `timeout`, `spin` parameters to `get_history` — enabling semaphore-based waiting for new data before returning history, and buffering a specified number of new writes before reading
- Fix `get_history` for complex datatypes
- Fix Apple platform detection

### C++ Bindings
- Update C++ bindings to use FIFO code; existing depth-1 SHM tests continue to pass
- Add segment overwrite check
- Add FIFO-specific tests; fix bug in `get_next_frame`
- Fix C++ interface on macOS

### Windows
- Merge and test Windows-specific changes across the FIFO implementation

### Documentation
- Add documentation and usage warnings for FIFO SHMs
- Clarify that depth-1 FIFO SHMs maintain backwards compatibility with legacy code

---

**Breaking changes:** The legacy C++ interface (`daoShmIfce.h`) is not yet updated for FIFO SHMs. Direct use of `IMAGE->array` and `IMAGE->md` pointers in legacy code has caveats — see commit notes for conditions under which it remains safe.