### PR TITLE
Add zero-copy ROI cropping (x=, y= slices) to shm get_data* methods

### DIFF
--- a/src/python/daoShm.py
+++ b/src/python/daoShm.py
@@ -567,7 +567,7 @@ class shm:
         nbVal = ctypes.c_uint32(data.size)
         result = self.daoShmImage2Shm(cData, nbVal, ctypes.byref(self.image))
 
-    def get_data_next(self, wait=False, reform=True):
+    def get_data_next(self, wait=False, reform=True, x=None, y=None):
         ''' --------------------------------------------------------------
         Reads and returns the next data part of the SHM file
 
@@ -575,6 +575,9 @@ class shm:
         ----------
         - wait: integer (last index) if not False, waits image update
         - reform: boolean, if True, reshapes the array in a 2-3D format
+        - x, y: optional slice objects to extract only a sub-region of the
+                image (e.g. x=slice(5,10), y=slice(10,15) for a 5x5 crop).
+                Same convention as get_data.
         -------------------------------------------------------------- '''
 
         if wait == True:
@@ -607,18 +610,29 @@ class shm:
             else:
                 data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1], arraySize[2]))#.astype(daoType2NpType(self.image.md.contents.atype))
 
+            # Apply the requested ROI to the zero-copy view *before* the
+            # complex-reconstruction/cast below, so only the sub-region ends
+            # up being copied out of shared memory instead of the whole frame.
+            if x is not None or y is not None:
+                ySlice = y if y is not None else slice(None)
+                xSlice = x if x is not None else slice(None)
+                if data.ndim == 1:
+                    data = data[xSlice]
+                else:
+                    data = data[ySlice, xSlice]
+
             # Check if the dtype is structured (i.e., for complex types)
             if data.dtype.fields is not None and 'real' in data.dtype.fields and 'imag' in data.dtype.fields:
                 # Reconstruct complex array by combining real and imaginary parts
                 data = data['real'] + 1j * data['imag']
-            
+
             # Cast to the desired NumPy type (e.g., complex64, complex128, or float, or...)
             data = data.astype(daoType2NpType(self.image.md.contents.atype))
-        
+
         return (result, data)
     
 
-    def get_data_arbitrary(self, index):
+    def get_data_arbitrary(self, index, x=None, y=None):
         ''' --------------------------------------------------------------
         Reads and returns the requested data segment of the SHM file
 
@@ -626,6 +640,9 @@ class shm:
         ----------
         - wait: integer (last index) if not False, waits image update
         - reform: boolean, if True, reshapes the array in a 2-3D format
+        - x, y: optional slice objects to extract only a sub-region of the
+                image (e.g. x=slice(5,10), y=slice(10,15) for a 5x5 crop).
+                Same convention as get_data.
         -------------------------------------------------------------- '''
 
         # First, check the requested number of items is valid
@@ -654,18 +671,29 @@ class shm:
         else:
             data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1], arraySize[2]))#.astype(daoType2NpType(self.image.md.contents.atype))
 
+        # Apply the requested ROI to the zero-copy view *before* the
+        # complex-reconstruction/cast below, so only the sub-region ends up
+        # being copied out of shared memory instead of the whole frame.
+        if x is not None or y is not None:
+            ySlice = y if y is not None else slice(None)
+            xSlice = x if x is not None else slice(None)
+            if data.ndim == 1:
+                data = data[xSlice]
+            else:
+                data = data[ySlice, xSlice]
+
         # Check if the dtype is structured (i.e., for complex types)
         if data.dtype.fields is not None and 'real' in data.dtype.fields and 'imag' in data.dtype.fields:
             # Reconstruct complex array by combining real and imaginary parts
             data = data['real'] + 1j * data['imag']
-        
+
         # Cast to the desired NumPy type (e.g., complex64, complex128, or float, or...)
         data = data.astype(daoType2NpType(self.image.md.contents.atype))
 
         return data
-    
 
-    def get_data(self, check=False, reform=True, semNb=0, timeout=0, spin=False):
+
+    def get_data(self, check=False, reform=True, semNb=0, timeout=0, spin=False, x=None, y=None):
         ''' --------------------------------------------------------------
         Reads and returns the newest data segment of the SHM file
 
@@ -673,6 +701,11 @@ class shm:
         ----------
         - check: integer (last index) if not False, waits image update
         - reform: boolean, if True, reshapes the array in a 2-3D format
+        - x, y: optional slice objects to extract only a sub-region of the
+                image (e.g. x=slice(5,10), y=slice(10,15) for a 5x5 crop).
+                The view onto shared memory is zero-copy regardless of
+                image size, so slicing it before the final dtype cast
+                means only the requested sub-region is actually copied.
         -------------------------------------------------------------- '''
         if check == True:
             if spin == True:
@@ -717,11 +750,22 @@ class shm:
         else:
             data=np.ctypeslib.as_array(arrayPtr, shape=(arraySize[0], arraySize[1], arraySize[2]))#.astype(daoType2NpType(self.image.md.contents.atype))
 
+        # Apply the requested ROI to the zero-copy view *before* the
+        # complex-reconstruction/cast below, so only the sub-region ends up
+        # being copied out of shared memory instead of the whole frame.
+        if x is not None or y is not None:
+            ySlice = y if y is not None else slice(None)
+            xSlice = x if x is not None else slice(None)
+            if data.ndim == 1:
+                data = data[xSlice]
+            else:
+                data = data[ySlice, xSlice]
+
         # Check if the dtype is structured (i.e., for complex types)
         if data.dtype.fields is not None and 'real' in data.dtype.fields and 'imag' in data.dtype.fields:
             # Reconstruct complex array by combining real and imaginary parts
             data = data['real'] + 1j * data['imag']
-        
+
         # Cast to the desired NumPy type (e.g., complex64, complex128, or float, or...)
         data = data.astype(daoType2NpType(self.image.md.contents.atype))
 
@@ -729,7 +773,7 @@ class shm:
 
 
 
-    def get_history(self, num_items=1, check=False, semNb=0, timeout=0, spin=False, buffer=False):
+    def get_history(self, num_items=1, check=False, semNb=0, timeout=0, spin=False, buffer=False, x=None, y=None):
         ''' --------------------------------------------------------------
         Reads and returns the last N segments written to the SHM
 
@@ -742,6 +786,10 @@ class shm:
         - spin:   if True, use counter-based wait instead of semaphore
         - buffer: if True, waits for num_items new writes since last call before
                   returning the array (implies semaphore waiting per write)
+        - x, y: optional slice objects to crop each returned frame to a
+                sub-region (e.g. x=slice(5,10), y=slice(10,15) for a 5x5
+                crop). Same convention as get_data - only the requested
+                sub-region is copied out of shared memory per history entry.
         -------------------------------------------------------------- '''
 
         # First, check the requested number of items is valid
@@ -787,11 +835,24 @@ class shm:
         
         if arraySize[2] == 0:
             if arraySize[1] == 0:
-                result_shape = (num_items, arraySize[0],)
+                frame_shape = (arraySize[0],)
             else:
-                result_shape = (num_items, arraySize[0], arraySize[1],)
+                frame_shape = (arraySize[0], arraySize[1])
         else:
-            result_shape = (num_items, arraySize[0], arraySize[1], arraySize[2])
+            frame_shape = (arraySize[0], arraySize[1], arraySize[2])
+
+        # Compute the cropped per-frame shape (if x/y were requested) so the
+        # preallocated history buffer, and thus every per-frame copy below,
+        # only ever holds the requested sub-region instead of full frames.
+        ySlice = y if y is not None else slice(None)
+        xSlice = x if x is not None else slice(None)
+        if len(frame_shape) == 1:
+            cropped_frame_shape = (len(range(*xSlice.indices(int(frame_shape[0])))),)
+        else:
+            cropped_frame_shape = (len(range(*ySlice.indices(int(frame_shape[0])))),
+                                    len(range(*xSlice.indices(int(frame_shape[1]))))) + tuple(frame_shape[2:])
+
+        result_shape = (num_items,) + cropped_frame_shape
 
         history_data = np.empty(result_shape, dtype=daoType2NpType(self.image.md.contents.atype))
 
@@ -807,8 +868,14 @@ class shm:
             arrayPtr = ctypes.c_void_p(None)
             self.daoShmGetArbitrarySegment(ctypes.byref(self.image), ctypes.byref(arrayPtr), ctypes.c_uint32(current_idx))
             arrayPtr = ctypes.cast(arrayPtr.value, ctypes.POINTER(element_ctype))
-            
-            current_data = np.ctypeslib.as_array(arrayPtr, shape=result_shape[1:])
+
+            current_data = np.ctypeslib.as_array(arrayPtr, shape=frame_shape)
+
+            if x is not None or y is not None:
+                if len(frame_shape) == 1:
+                    current_data = current_data[xSlice]
+                else:
+                    current_data = current_data[ySlice, xSlice]
 
             if current_data.dtype.fields is not None \
                     and 'real' in current_data.dtype.fields \


### PR DESCRIPTION
## Summary

Adds optional `x=`/`y=` slice keyword arguments to `shm.get_data()`, `get_data_next()`, `get_data_arbitrary()`, and `get_history()` in `daoShm.py`, allowing callers to extract only a sub-region of a frame directly from shared memory instead of reading the whole image.

```python
crop = shm.get_data(x=slice(50, 55), y=slice(5, 10))   # 5x5 crop
full = shm.get_data()                                    # unchanged, full frame
```

`y` indexes axis 0 (rows), `x` indexes axis 1 (columns) — matches numpy's `arr[y, x]` convention.

## Motivation

Each of these methods wraps the raw ctypes pointer as a zero-copy numpy view, but then always calls `.astype(...)` on the *full* frame before returning (needed for the complex real/imag reconstruction and dtype normalization). If a caller only wanted a small ROI, the old pattern

```python
shm.get_data()[y0:y1, x0:x1]
```

still pays for a full-frame copy every call — the slice only discards data *after* it's already been copied. For large frames or high frame-rate acquisition this copy dominates and caps the achievable read rate well below what the camera can deliver.

## Fix

Slice the zero-copy ctypes view **before** the complex-reconstruction/`.astype()` step, so the copy only ever touches the requested sub-region. `get_history` additionally preallocates its output buffer at the cropped shape instead of the full frame shape, so the per-frame copy in its loop is bounded the same way.

## Backward compatibility

`x`/`y` default to `None` (full frame). When neither is passed, the code path is identical to before — same behavior, same output, same performance characteristics. No existing call sites are affected.

## Safety

No manual bounds checking was added, and none is needed: numpy clips slice indices to the array's declared shape internally (same semantics as any Python slice), so an oversized or malformed `x=`/`y=` request can't read outside the buffer — it just silently clips to the valid intersection, exactly like `some_list[5:10000]` would.

## Performance

Synthetic benchmark, 4096x4096 float32 frame, 5x5 crop:
- old (`get_data()[y0:y1, x0:x1]`): ~125 ms
- new (`get_data(x=..., y=...)`): ~0.014 ms
- **~8800x faster**

Real-world validation, 1480x1480 camera @ 400 Hz, 100x100 ROI via `get_data(check=True, semNb=2, x=slice(0,100), y=slice(0,100))`:
- old: **140 Hz**
- new: **395.8 Hz** — essentially camera-rate-limited (bound by the semaphore wait, not the copy) rather than copy-limited.

## Test plan

- [x] Manual syntax/import check (`ast.parse`)
- [x] Verified slicing semantics against a standalone ctypes-backed numpy view (crop shape, values, and out-of-range clipping)
- [x] Verified default (`x=None, y=None`) path is unchanged
- [x] Confirmed on real hardware (1480x1480 @ 400 Hz camera) — throughput improved from 140 Hz to 395.8 Hz
- [ ] Reviewer: sanity check on a 1D/3D SHM (FIFO / cube) if one is available, since this repo doesn't have a test harness for those locally
