### PR TITLE
Update IMAGE_METADATA ctypes struct to match dao.h alterations

### DIFF
--- a/src/python/daoShm.py
+++ b/src/python/daoShm.py
@@ -232,7 +232,7 @@ if sys.platform == "darwin":
             ("lastNb", ctypes.c_uint32),
             ("packetNb", ctypes.c_uint32),
             ("packetTotal", ctypes.c_uint32),
-            ("lastNbArray", ctypes.c_uint64 * 512),
+            ("lastNbArray", ctypes.c_uint64 * 2024),
             ("semCounter", ctypes.c_uint32 * 10),
             ("semLogCounter", ctypes.c_uint32),
             ("fifo_size", ctypes.c_uint32),
@@ -269,7 +269,7 @@ else:
             ("lastNb", ctypes.c_uint32),
             ("packetNb", ctypes.c_uint32),
             ("packetTotal", ctypes.c_uint32),
-            ("lastNbArray", ctypes.c_uint64 * 512),
+            ("lastNbArray", ctypes.c_uint64 * 2024),
             ("fifo_size", ctypes.c_uint32),
             ("fifo_last_written", ctypes.c_uint32)
         ]


### PR DESCRIPTION
This updates daoShm.py to mirror the change made in dao.h to IMAGE_METADATA's lastNbArray (in commit 2d516b2aec3f80094901ed6422ce1d89a4c173b9)